### PR TITLE
Add simple web status page

### DIFF
--- a/ZigbeeHomeAutomation/Helpers/AppSettings.cs
+++ b/ZigbeeHomeAutomation/Helpers/AppSettings.cs
@@ -17,5 +17,6 @@ namespace ZigbeeHomeAutomation.Helpers
         public static string MqttIp => Configuration["Mqtt:BrokerIp"];
         public static int MqttPort => int.Parse(Configuration["Mqtt:BrokerPort"] ?? "1883");
         public static int LoopIntervalSeconds => int.Parse(Configuration["System:LoopIntervalSeconds"] ?? "5");
+        public static int HttpPort => int.Parse(Configuration["HttpServer:Port"] ?? "8080");
     }
 }

--- a/ZigbeeHomeAutomation/Helpers/WebServer.cs
+++ b/ZigbeeHomeAutomation/Helpers/WebServer.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using ZigbeeHomeAutomation.Models;
+using Newtonsoft.Json;
+
+namespace ZigbeeHomeAutomation.Helpers
+{
+    public static class WebServer
+    {
+        private static HttpListener? _listener;
+
+        public static async Task StartAsync()
+        {
+            _listener = new HttpListener();
+            string prefix = $"http://*:{AppSettings.HttpPort}/";
+            _listener.Prefixes.Add(prefix);
+            _listener.Start();
+            Console.WriteLine($"🌐 Web server listening on {prefix}");
+
+            while (true)
+            {
+                try
+                {
+                    var context = await _listener.GetContextAsync();
+                    _ = Task.Run(() => HandleRequest(context));
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"WebServer error: {ex.Message}");
+                    await Task.Delay(1000);
+                }
+            }
+        }
+
+        private static void HandleRequest(HttpListenerContext context)
+        {
+            try
+            {
+                string html = GenerateStatusHtml();
+                byte[] buffer = Encoding.UTF8.GetBytes(html);
+                context.Response.ContentType = "text/html";
+                context.Response.ContentLength64 = buffer.Length;
+                context.Response.OutputStream.Write(buffer, 0, buffer.Length);
+            }
+            finally
+            {
+                context.Response.OutputStream.Close();
+            }
+        }
+
+        private static string GenerateStatusHtml()
+        {
+            var sb = new StringBuilder();
+            sb.Append("<html><head><title>Zigbee Home Automation</title></head><body>");
+            sb.Append("<h1>Zigbee Home Automation</h1>");
+            sb.Append($"<p>Application running at {DateTime.Now}</p>");
+            sb.Append("<h2>Sensor States</h2><ul>");
+
+            foreach (var sensor in SensorStateStore.SensorValues)
+            {
+                string json = JsonConvert.SerializeObject(sensor.Value);
+                sb.Append($"<li><b>{sensor.Key}</b>: {json}</li>");
+            }
+            if (SensorStateStore.SensorValues.Count == 0)
+            {
+                sb.Append("<li>No sensors tracked.</li>");
+            }
+
+            sb.Append("</ul></body></html>");
+            return sb.ToString();
+        }
+    }
+}

--- a/ZigbeeHomeAutomation/Program.cs
+++ b/ZigbeeHomeAutomation/Program.cs
@@ -18,6 +18,9 @@ class Program
 
         Console.WriteLine("Connected to MQTT. Starting loop...");
 
+        // Start the simple web server for health checks
+        _ = Task.Run(() => WebServer.StartAsync());
+
         int delay = AppSettings.LoopIntervalSeconds;
 
         while (true)

--- a/ZigbeeHomeAutomation/appSettings.json
+++ b/ZigbeeHomeAutomation/appSettings.json
@@ -5,5 +5,8 @@
   },
   "System": {
     "LoopIntervalSeconds": 1
+  },
+  "HttpServer": {
+    "Port": 8080
   }
 }


### PR DESCRIPTION
## Summary
- add a lightweight web server (`WebServer.cs`) that displays current sensor states
- expose new `HttpServer:Port` option
- start the status server in `Program.cs`

## Testing
- `dotnet build ZigbeeHomeAutomation/ZigbeeHomeAutomation.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6859981f8058832190be546bf5169b70