### PR TITLE
Add HomeAuthomationAPI web API

### DIFF
--- a/HomeAuthomationAPI.sln
+++ b/HomeAuthomationAPI.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HomeAuthomationAPI", "HomeAuthomationAPI\HomeAuthomationAPI.csproj", "{E486174D-0ACF-483B-A8BD-36E36D0CA568}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E486174D-0ACF-483B-A8BD-36E36D0CA568}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E486174D-0ACF-483B-A8BD-36E36D0CA568}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E486174D-0ACF-483B-A8BD-36E36D0CA568}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E486174D-0ACF-483B-A8BD-36E36D0CA568}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/HomeAuthomationAPI/Controllers/ConfigurationsController.cs
+++ b/HomeAuthomationAPI/Controllers/ConfigurationsController.cs
@@ -1,0 +1,59 @@
+using HomeAuthomationAPI.Data;
+using HomeAuthomationAPI.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HomeAuthomationAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ConfigurationsController : ControllerBase
+    {
+        private readonly HomeAutomationContext _context;
+        public ConfigurationsController(HomeAutomationContext context)
+        {
+            _context = context;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Configuration>>> Get()
+        {
+            return await _context.Configurations.ToListAsync();
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Configuration>> Get(int id)
+        {
+            var config = await _context.Configurations.FindAsync(id);
+            if (config == null) return NotFound();
+            return config;
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<Configuration>> Post(Configuration config)
+        {
+            _context.Configurations.Add(config);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), new { id = config.Id }, config);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Put(int id, Configuration config)
+        {
+            if (id != config.Id) return BadRequest();
+            _context.Entry(config).State = EntityState.Modified;
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var config = await _context.Configurations.FindAsync(id);
+            if (config == null) return NotFound();
+            _context.Configurations.Remove(config);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/HomeAuthomationAPI/Controllers/OrganisationsController.cs
+++ b/HomeAuthomationAPI/Controllers/OrganisationsController.cs
@@ -1,0 +1,65 @@
+using HomeAuthomationAPI.Data;
+using HomeAuthomationAPI.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HomeAuthomationAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class OrganisationsController : ControllerBase
+    {
+        private readonly HomeAutomationContext _context;
+        public OrganisationsController(HomeAutomationContext context)
+        {
+            _context = context;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Organisation>>> Get()
+        {
+            return await _context.Organisations
+                .Include(o => o.Properties)
+                .Include(o => o.Users)
+                .ToListAsync();
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Organisation>> Get(int id)
+        {
+            var organisation = await _context.Organisations
+                .Include(o => o.Properties)
+                .Include(o => o.Users)
+                .FirstOrDefaultAsync(o => o.Id == id);
+            if (organisation == null) return NotFound();
+            return organisation;
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<Organisation>> Post(Organisation organisation)
+        {
+            _context.Organisations.Add(organisation);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), new { id = organisation.Id }, organisation);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Put(int id, Organisation organisation)
+        {
+            if (id != organisation.Id) return BadRequest();
+            _context.Entry(organisation).State = EntityState.Modified;
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var organisation = await _context.Organisations.FindAsync(id);
+            if (organisation == null) return NotFound();
+            _context.Organisations.Remove(organisation);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/HomeAuthomationAPI/Controllers/PropertiesController.cs
+++ b/HomeAuthomationAPI/Controllers/PropertiesController.cs
@@ -1,0 +1,59 @@
+using HomeAuthomationAPI.Data;
+using HomeAuthomationAPI.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HomeAuthomationAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class PropertiesController : ControllerBase
+    {
+        private readonly HomeAutomationContext _context;
+        public PropertiesController(HomeAutomationContext context)
+        {
+            _context = context;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Property>>> Get()
+        {
+            return await _context.Properties.Include(p => p.Configuration).ToListAsync();
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Property>> Get(int id)
+        {
+            var property = await _context.Properties.Include(p => p.Configuration).FirstOrDefaultAsync(p => p.Id == id);
+            if (property == null) return NotFound();
+            return property;
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<Property>> Post(Property property)
+        {
+            _context.Properties.Add(property);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), new { id = property.Id }, property);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Put(int id, Property property)
+        {
+            if (id != property.Id) return BadRequest();
+            _context.Entry(property).State = EntityState.Modified;
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var property = await _context.Properties.FindAsync(id);
+            if (property == null) return NotFound();
+            _context.Properties.Remove(property);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/HomeAuthomationAPI/Controllers/UsersController.cs
+++ b/HomeAuthomationAPI/Controllers/UsersController.cs
@@ -1,0 +1,105 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using HomeAuthomationAPI.Data;
+using HomeAuthomationAPI.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+
+namespace HomeAuthomationAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class UsersController : ControllerBase
+    {
+        private readonly HomeAutomationContext _context;
+        private readonly IConfiguration _config;
+        private readonly PasswordHasher<User> _hasher = new();
+
+        public UsersController(HomeAutomationContext context, IConfiguration config)
+        {
+            _context = context;
+            _config = config;
+        }
+
+        [HttpGet]
+        [Authorize]
+        public async Task<ActionResult<IEnumerable<User>>> Get()
+        {
+            return await _context.Users.ToListAsync();
+        }
+
+        [HttpGet("{id}")]
+        [Authorize]
+        public async Task<ActionResult<User>> Get(int id)
+        {
+            var user = await _context.Users.FindAsync(id);
+            if (user == null) return NotFound();
+            return user;
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<User>> Register(User user)
+        {
+            user.PasswordHash = _hasher.HashPassword(user, user.PasswordHash);
+            _context.Users.Add(user);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), new { id = user.Id }, user);
+        }
+
+        [HttpPost("login")]
+        public async Task<IActionResult> Login(LoginDto dto)
+        {
+            var user = await _context.Users.SingleOrDefaultAsync(u => u.Username == dto.Username);
+            if (user == null) return Unauthorized();
+            var result = _hasher.VerifyHashedPassword(user, user.PasswordHash, dto.Password);
+            if (result != PasswordVerificationResult.Success) return Unauthorized();
+            var token = GenerateToken(user);
+            return Ok(new { token });
+        }
+
+        [HttpPut("{id}")]
+        [Authorize]
+        public async Task<IActionResult> Put(int id, User user)
+        {
+            if (id != user.Id) return BadRequest();
+            _context.Entry(user).State = EntityState.Modified;
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        [Authorize]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var user = await _context.Users.FindAsync(id);
+            if (user == null) return NotFound();
+            _context.Users.Remove(user);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        private string GenerateToken(User user)
+        {
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]!));
+            var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+            var claims = new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
+                new Claim(ClaimTypes.Name, user.Username)
+            };
+            var token = new JwtSecurityToken(
+                issuer: _config["Jwt:Issuer"],
+                audience: null,
+                claims: claims,
+                expires: DateTime.UtcNow.AddHours(1),
+                signingCredentials: creds);
+            return new JwtSecurityTokenHandler().WriteToken(token);
+        }
+
+        public record LoginDto(string Username, string Password);
+    }
+}

--- a/HomeAuthomationAPI/Data/HomeAutomationContext.cs
+++ b/HomeAuthomationAPI/Data/HomeAutomationContext.cs
@@ -1,0 +1,25 @@
+using HomeAuthomationAPI.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace HomeAuthomationAPI.Data
+{
+    public class HomeAutomationContext : DbContext
+    {
+        public HomeAutomationContext(DbContextOptions<HomeAutomationContext> options) : base(options)
+        {
+        }
+
+        public DbSet<Organisation> Organisations => Set<Organisation>();
+        public DbSet<Property> Properties => Set<Property>();
+        public DbSet<Configuration> Configurations => Set<Configuration>();
+        public DbSet<User> Users => Set<User>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Property>()
+                .HasOne(p => p.Configuration)
+                .WithOne(c => c.Property!)
+                .HasForeignKey<Configuration>(c => c.PropertyId);
+        }
+    }
+}

--- a/HomeAuthomationAPI/HomeAuthomationAPI.csproj
+++ b/HomeAuthomationAPI/HomeAuthomationAPI.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+</Project>

--- a/HomeAuthomationAPI/HomeAuthomationAPI.http
+++ b/HomeAuthomationAPI/HomeAuthomationAPI.http
@@ -1,0 +1,6 @@
+@HomeAuthomationAPI_HostAddress = http://localhost:5029
+
+GET {{HomeAuthomationAPI_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/HomeAuthomationAPI/Models/Configuration.cs
+++ b/HomeAuthomationAPI/Models/Configuration.cs
@@ -1,0 +1,10 @@
+namespace HomeAuthomationAPI.Models
+{
+    public class Configuration
+    {
+        public int Id { get; set; }
+        public int PropertyId { get; set; }
+        public Property? Property { get; set; }
+        public string Content { get; set; } = string.Empty; // configuration file content
+    }
+}

--- a/HomeAuthomationAPI/Models/Organisation.cs
+++ b/HomeAuthomationAPI/Models/Organisation.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace HomeAuthomationAPI.Models
+{
+    public class Organisation
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public ICollection<Property> Properties { get; set; } = new List<Property>();
+        public ICollection<User> Users { get; set; } = new List<User>();
+    }
+}

--- a/HomeAuthomationAPI/Models/Property.cs
+++ b/HomeAuthomationAPI/Models/Property.cs
@@ -1,0 +1,11 @@
+namespace HomeAuthomationAPI.Models
+{
+    public class Property
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public int OrganisationId { get; set; }
+        public Organisation? Organisation { get; set; }
+        public Configuration? Configuration { get; set; }
+    }
+}

--- a/HomeAuthomationAPI/Models/User.cs
+++ b/HomeAuthomationAPI/Models/User.cs
@@ -1,0 +1,11 @@
+namespace HomeAuthomationAPI.Models
+{
+    public class User
+    {
+        public int Id { get; set; }
+        public string Username { get; set; } = string.Empty;
+        public string PasswordHash { get; set; } = string.Empty;
+        public int OrganisationId { get; set; }
+        public Organisation? Organisation { get; set; }
+    }
+}

--- a/HomeAuthomationAPI/Program.cs
+++ b/HomeAuthomationAPI/Program.cs
@@ -1,0 +1,47 @@
+using HomeAuthomationAPI.Data;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddDbContext<HomeAutomationContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = false,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = builder.Configuration["Jwt:Issuer"],
+            IssuerSigningKey = new SymmetricSecurityKey(
+                Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!))
+        };
+    });
+
+builder.Services.AddAuthorization();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/HomeAuthomationAPI/Properties/launchSettings.json
+++ b/HomeAuthomationAPI/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:9364",
+      "sslPort": 44377
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5029",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7119;http://localhost:5029",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/HomeAuthomationAPI/appsettings.Development.json
+++ b/HomeAuthomationAPI/appsettings.Development.json
@@ -1,0 +1,15 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Debug"
+    }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=HomeAutomationDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "Jwt": {
+    "Key": "supersecretkey12345",
+    "Issuer": "HomeAutomationAPI"
+  }
+}

--- a/HomeAuthomationAPI/appsettings.json
+++ b/HomeAuthomationAPI/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=HomeAutomationDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "Jwt": {
+    "Key": "supersecretkey12345",
+    "Issuer": "HomeAutomationAPI"
+  }
+}


### PR DESCRIPTION
## Summary
- add HomeAuthomationAPI solution
- implement EF Core context and models
- add controllers for organisations, properties, configurations and users
- enable JWT authentication
- add appsettings with connection string and JWT settings

## Testing
- `dotnet build HomeAuthomationAPI/HomeAuthomationAPI.csproj -nologo`
- `dotnet test HomeAuthomationAPI.sln -nologo`

------
https://chatgpt.com/codex/tasks/task_e_6859b5c8912c83218c0fbd96befa9587