### PR TITLE
Add device and router models

### DIFF
--- a/HomeAuthomationAPI/Controllers/DevicesController.cs
+++ b/HomeAuthomationAPI/Controllers/DevicesController.cs
@@ -1,0 +1,65 @@
+using HomeAuthomationAPI.Data;
+using HomeAuthomationAPI.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HomeAuthomationAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class DevicesController : ControllerBase
+    {
+        private readonly HomeAutomationContext _context;
+        public DevicesController(HomeAutomationContext context)
+        {
+            _context = context;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Device>>> Get()
+        {
+            return await _context.Devices
+                .Include(d => d.Parameters)
+                .Include(d => d.Configurations)
+                .ToListAsync();
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Device>> Get(int id)
+        {
+            var device = await _context.Devices
+                .Include(d => d.Parameters)
+                .Include(d => d.Configurations)
+                .FirstOrDefaultAsync(d => d.Id == id);
+            if (device == null) return NotFound();
+            return device;
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<Device>> Post(Device device)
+        {
+            _context.Devices.Add(device);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), new { id = device.Id }, device);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Put(int id, Device device)
+        {
+            if (id != device.Id) return BadRequest();
+            _context.Entry(device).State = EntityState.Modified;
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var device = await _context.Devices.FindAsync(id);
+            if (device == null) return NotFound();
+            _context.Devices.Remove(device);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/HomeAuthomationAPI/Controllers/RouterDevicesController.cs
+++ b/HomeAuthomationAPI/Controllers/RouterDevicesController.cs
@@ -1,0 +1,65 @@
+using HomeAuthomationAPI.Data;
+using HomeAuthomationAPI.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HomeAuthomationAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class RouterDevicesController : ControllerBase
+    {
+        private readonly HomeAutomationContext _context;
+        public RouterDevicesController(HomeAutomationContext context)
+        {
+            _context = context;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<RouterDevice>>> Get()
+        {
+            return await _context.RouterDevices
+                .Include(r => r.Devices)
+                .Include(r => r.Configurations)
+                .ToListAsync();
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<RouterDevice>> Get(int id)
+        {
+            var router = await _context.RouterDevices
+                .Include(r => r.Devices)
+                .Include(r => r.Configurations)
+                .FirstOrDefaultAsync(r => r.Id == id);
+            if (router == null) return NotFound();
+            return router;
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<RouterDevice>> Post(RouterDevice router)
+        {
+            _context.RouterDevices.Add(router);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), new { id = router.Id }, router);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Put(int id, RouterDevice router)
+        {
+            if (id != router.Id) return BadRequest();
+            _context.Entry(router).State = EntityState.Modified;
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var router = await _context.RouterDevices.FindAsync(id);
+            if (router == null) return NotFound();
+            _context.RouterDevices.Remove(router);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/HomeAuthomationAPI/Data/HomeAutomationContext.cs
+++ b/HomeAuthomationAPI/Data/HomeAutomationContext.cs
@@ -13,6 +13,9 @@ namespace HomeAuthomationAPI.Data
         public DbSet<Property> Properties => Set<Property>();
         public DbSet<Configuration> Configurations => Set<Configuration>();
         public DbSet<User> Users => Set<User>();
+        public DbSet<RouterDevice> RouterDevices => Set<RouterDevice>();
+        public DbSet<Device> Devices => Set<Device>();
+        public DbSet<Parameter> Parameters => Set<Parameter>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -20,6 +23,35 @@ namespace HomeAuthomationAPI.Data
                 .HasOne(p => p.Configuration)
                 .WithOne(c => c.Property!)
                 .HasForeignKey<Configuration>(c => c.PropertyId);
+
+            modelBuilder.Entity<Property>()
+                .HasMany(p => p.RouterDevices)
+                .WithOne(r => r.Property)
+                .HasForeignKey(r => r.PropertyId);
+
+            modelBuilder.Entity<RouterDevice>()
+                .HasIndex(r => r.UniqueId)
+                .IsUnique();
+
+            modelBuilder.Entity<RouterDevice>()
+                .HasMany(r => r.Devices)
+                .WithOne(d => d.RouterDevice)
+                .HasForeignKey(d => d.RouterDeviceId);
+
+            modelBuilder.Entity<Device>()
+                .HasMany(d => d.Parameters)
+                .WithOne(p => p.Device!)
+                .HasForeignKey(p => p.DeviceId);
+
+            modelBuilder.Entity<Device>()
+                .HasMany(d => d.Configurations)
+                .WithOne(c => c.Device)
+                .HasForeignKey(c => c.DeviceId);
+
+            modelBuilder.Entity<RouterDevice>()
+                .HasMany(r => r.Configurations)
+                .WithOne(c => c.RouterDevice)
+                .HasForeignKey(c => c.RouterDeviceId);
         }
     }
 }

--- a/HomeAuthomationAPI/Models/Configuration.cs
+++ b/HomeAuthomationAPI/Models/Configuration.cs
@@ -3,8 +3,16 @@ namespace HomeAuthomationAPI.Models
     public class Configuration
     {
         public int Id { get; set; }
-        public int PropertyId { get; set; }
+
+        public int? PropertyId { get; set; }
         public Property? Property { get; set; }
+
+        public int? RouterDeviceId { get; set; }
+        public RouterDevice? RouterDevice { get; set; }
+
+        public int? DeviceId { get; set; }
+        public Device? Device { get; set; }
+
         public string Content { get; set; } = string.Empty; // configuration file content
     }
 }

--- a/HomeAuthomationAPI/Models/Device.cs
+++ b/HomeAuthomationAPI/Models/Device.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace HomeAuthomationAPI.Models
+{
+    public class Device
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public int RouterDeviceId { get; set; }
+        public RouterDevice? RouterDevice { get; set; }
+        public ICollection<Parameter> Parameters { get; set; } = new List<Parameter>();
+        public ICollection<Configuration> Configurations { get; set; } = new List<Configuration>();
+    }
+}

--- a/HomeAuthomationAPI/Models/Parameter.cs
+++ b/HomeAuthomationAPI/Models/Parameter.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace HomeAuthomationAPI.Models
+{
+    public class Parameter
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public bool IsSensor { get; set; }
+        public int DeviceId { get; set; }
+        public Device? Device { get; set; }
+    }
+}

--- a/HomeAuthomationAPI/Models/Property.cs
+++ b/HomeAuthomationAPI/Models/Property.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace HomeAuthomationAPI.Models
 {
     public class Property
@@ -7,5 +9,7 @@ namespace HomeAuthomationAPI.Models
         public int OrganisationId { get; set; }
         public Organisation? Organisation { get; set; }
         public Configuration? Configuration { get; set; }
+
+        public ICollection<RouterDevice> RouterDevices { get; set; } = new List<RouterDevice>();
     }
 }

--- a/HomeAuthomationAPI/Models/RouterDevice.cs
+++ b/HomeAuthomationAPI/Models/RouterDevice.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace HomeAuthomationAPI.Models
+{
+    public class RouterDevice
+    {
+        public int Id { get; set; }
+        public string FriendlyName { get; set; } = string.Empty;
+        public string UniqueId { get; set; } = string.Empty;
+        public int PropertyId { get; set; }
+        public Property? Property { get; set; }
+        public ICollection<Device> Devices { get; set; } = new List<Device>();
+        public ICollection<Configuration> Configurations { get; set; } = new List<Configuration>();
+    }
+}


### PR DESCRIPTION
## Summary
- add `Device`, `RouterDevice`, and `Parameter` models
- link new models in `HomeAutomationContext`
- extend `Configuration` for router and device associations
- expose CRUD endpoints for RouterDevices and Devices
- update `Property` to track router devices

## Testing
- `dotnet build HomeAuthomationAPI/HomeAuthomationAPI.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_68611e1b0ca083219bdd974a3fe755b5