### PR TITLE
Implement periodic API sync with router device

### DIFF
--- a/HomeAuthomationAPI/Controllers/SyncController.cs
+++ b/HomeAuthomationAPI/Controllers/SyncController.cs
@@ -1,0 +1,51 @@
+using HomeAuthomationAPI.Data;
+using HomeAuthomationAPI.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
+
+namespace HomeAuthomationAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class SyncController : ControllerBase
+    {
+        private readonly HomeAutomationContext _context;
+        public SyncController(HomeAutomationContext context)
+        {
+            _context = context;
+        }
+
+        public class SyncRequest
+        {
+            public string RouterDeviceId { get; set; } = string.Empty;
+            public Dictionary<string, Dictionary<string, object>> DeviceStatuses { get; set; } = new();
+        }
+
+        public class SyncResponse
+        {
+            public string? ConfigurationContent { get; set; }
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<SyncResponse>> Post(SyncRequest request)
+        {
+            var status = new DeviceStatus
+            {
+                RouterDeviceId = request.RouterDeviceId,
+                Timestamp = DateTime.UtcNow,
+                StatusJson = JsonSerializer.Serialize(request.DeviceStatuses)
+            };
+            _context.DeviceStatuses.Add(status);
+            await _context.SaveChangesAsync();
+
+            var property = await _context.Properties
+                .Include(p => p.Configuration)
+                .FirstOrDefaultAsync(p => p.RouterDeviceId == request.RouterDeviceId);
+
+            string? config = property?.Configuration?.Content;
+
+            return Ok(new SyncResponse { ConfigurationContent = config });
+        }
+    }
+}

--- a/HomeAuthomationAPI/Data/HomeAutomationContext.cs
+++ b/HomeAuthomationAPI/Data/HomeAutomationContext.cs
@@ -13,6 +13,7 @@ namespace HomeAuthomationAPI.Data
         public DbSet<Property> Properties => Set<Property>();
         public DbSet<Configuration> Configurations => Set<Configuration>();
         public DbSet<User> Users => Set<User>();
+        public DbSet<DeviceStatus> DeviceStatuses => Set<DeviceStatus>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/HomeAuthomationAPI/Models/DeviceStatus.cs
+++ b/HomeAuthomationAPI/Models/DeviceStatus.cs
@@ -1,0 +1,10 @@
+namespace HomeAuthomationAPI.Models
+{
+    public class DeviceStatus
+    {
+        public int Id { get; set; }
+        public string RouterDeviceId { get; set; } = string.Empty;
+        public DateTime Timestamp { get; set; }
+        public string StatusJson { get; set; } = string.Empty;
+    }
+}

--- a/HomeAuthomationAPI/Models/Property.cs
+++ b/HomeAuthomationAPI/Models/Property.cs
@@ -4,6 +4,7 @@ namespace HomeAuthomationAPI.Models
     {
         public int Id { get; set; }
         public string Name { get; set; } = string.Empty;
+        public string RouterDeviceId { get; set; } = string.Empty;
         public int OrganisationId { get; set; }
         public Organisation? Organisation { get; set; }
         public Configuration? Configuration { get; set; }

--- a/ZigbeeHomeAutomation/Configs/configuration.json
+++ b/ZigbeeHomeAutomation/Configs/configuration.json
@@ -1,6 +1,7 @@
 {
   "ConfigurationName": "Night Security",
   "ConfigurationDate": "2025-06-10T12:00:00",
+  "RouterDeviceId": "router1",
   "Rules": [
     {
       "conditon": [

--- a/ZigbeeHomeAutomation/Helpers/AppSettings.cs
+++ b/ZigbeeHomeAutomation/Helpers/AppSettings.cs
@@ -17,6 +17,8 @@ namespace ZigbeeHomeAutomation.Helpers
         public static string MqttIp => Configuration["Mqtt:BrokerIp"];
         public static int MqttPort => int.Parse(Configuration["Mqtt:BrokerPort"] ?? "1883");
         public static int LoopIntervalSeconds => int.Parse(Configuration["System:LoopIntervalSeconds"] ?? "5");
-        public static int HttpPort => int.Parse(Configuration["HttpServer:Port"] ?? "8080");
+        public static int HttpPort => int.Parse(Configuration["HttpServer:Port"] ?? "8889");
+        public static string ApiBaseUrl => Configuration["HomeAutomationApi:BaseUrl"] ?? string.Empty;
+        public static int ApiSyncIntervalSeconds => int.Parse(Configuration["HomeAutomationApi:SyncIntervalSeconds"] ?? "30");
     }
 }

--- a/ZigbeeHomeAutomation/Helpers/HomeAutomationApiClient.cs
+++ b/ZigbeeHomeAutomation/Helpers/HomeAutomationApiClient.cs
@@ -1,0 +1,72 @@
+using System.Text;
+using System.Net.Http;
+using Newtonsoft.Json;
+
+namespace ZigbeeHomeAutomation.Helpers
+{
+    public static class HomeAutomationApiClient
+    {
+        private static readonly HttpClient _httpClient = new HttpClient();
+
+        private class SyncResponse
+        {
+            public string? ConfigurationContent { get; set; }
+        }
+
+        public static async Task SyncAsync()
+        {
+            var allConfigs = ConfigurationFileLoader.LoadAllConfigurationsFromFolder();
+            var latest = ConfigurationHelper.GetLatestConfiguration(allConfigs);
+            if (latest == null) return;
+
+            var payload = new
+            {
+                routerDeviceId = latest.RouterDeviceId,
+                deviceStatuses = SensorStateStore.SensorValues.ToDictionary(k => k.Key, k => k.Value)
+            };
+
+            var json = JsonConvert.SerializeObject(payload);
+            try
+            {
+                var resp = await _httpClient.PostAsync($"{AppSettings.ApiBaseUrl}/sync",
+                    new StringContent(json, Encoding.UTF8, "application/json"));
+                if (!resp.IsSuccessStatusCode)
+                {
+                    Console.WriteLine($"API sync failed: {resp.StatusCode}");
+                    return;
+                }
+
+                var body = await resp.Content.ReadAsStringAsync();
+                var respObj = JsonConvert.DeserializeObject<SyncResponse>(body);
+                if (respObj?.ConfigurationContent != null)
+                {
+                    UpdateConfigurationIfNeeded(respObj.ConfigurationContent);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"API sync error: {ex.Message}");
+            }
+        }
+
+        private static void UpdateConfigurationIfNeeded(string newConfig)
+        {
+            string basePath = AppContext.BaseDirectory;
+            string configPath = Path.Combine(basePath, "Configs", "configuration.json");
+
+            try
+            {
+                string? existing = File.Exists(configPath) ? File.ReadAllText(configPath) : null;
+                if (existing != newConfig)
+                {
+                    File.WriteAllText(configPath, newConfig);
+                    Console.WriteLine("Updated configuration from server.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to write configuration: {ex.Message}");
+            }
+        }
+    }
+}

--- a/ZigbeeHomeAutomation/Models/Configuration.cs
+++ b/ZigbeeHomeAutomation/Models/Configuration.cs
@@ -13,5 +13,7 @@ namespace ZigbeeHomeAutomation.Models
         public DateTime ConfigurationDate {  get; set; }
 
         public string ConfigurationName { get; set; }
+
+        public string RouterDeviceId { get; set; } = string.Empty;
     }
 }

--- a/ZigbeeHomeAutomation/Program.cs
+++ b/ZigbeeHomeAutomation/Program.cs
@@ -21,6 +21,7 @@ class Program
 
         // Start the simple web server for health checks
         _ = Task.Run(() => WebServer.StartAsync());
+        _ = Task.Run(() => ApiSyncLoop());
 
         int delay = AppSettings.LoopIntervalSeconds;
 
@@ -56,5 +57,15 @@ class Program
         RuleExecutionHelper.CompileAndExecuteRules(latestConfig, compiler);
 
 
+    }
+
+    static async Task ApiSyncLoop()
+    {
+        int delay = AppSettings.ApiSyncIntervalSeconds;
+        while (true)
+        {
+            await HomeAutomationApiClient.SyncAsync();
+            await Task.Delay(delay * 1000);
+        }
     }
 }

--- a/ZigbeeHomeAutomation/appSettings.json
+++ b/ZigbeeHomeAutomation/appSettings.json
@@ -7,6 +7,10 @@
     "LoopIntervalSeconds": 1
   },
   "HttpServer": {
-    "Port": 8080
+    "Port": 8889
+  },
+  "HomeAutomationApi": {
+    "BaseUrl": "http://localhost:5000/api",
+    "SyncIntervalSeconds": 30
   }
 }


### PR DESCRIPTION
## Summary
- add router device ID to configuration file and model
- configure Home Automation API URL and sync interval
- implement API client and sync loop in Zigbee app
- extend database context with device status tracking
- add API controller to accept statuses and return configuration
- include router device ID in property model
- change HTTP server port to 8889

## Testing
- `dotnet build ZigbeeHomeAutomation/ZigbeeHomeAutomation.csproj -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861700fc15c8321918e553327ce98f2