### PR TITLE
Add property device management in Blazor app

### DIFF
--- a/HomeAutomationBlazor/Components/Pages/Properties.razor
+++ b/HomeAutomationBlazor/Components/Pages/Properties.razor
@@ -23,6 +23,7 @@ else
                 <th>Router</th>
                 <th>Organisation</th>
                 <th></th>
+                <th></th>
             </tr>
         </thead>
         <tbody>
@@ -32,6 +33,9 @@ else
                 <td>@p.Name</td>
                 <td>@p.RouterDeviceId</td>
                 <td>@p.OrganisationId</td>
+                <td>
+                    <NavLink class="btn btn-sm btn-secondary" href="/properties/@p.Id">Manage</NavLink>
+                </td>
                 <td>
                     <button class="btn btn-sm btn-danger" @onclick="() => Delete(p.Id)">Delete</button>
                 </td>

--- a/HomeAutomationBlazor/Components/Pages/PropertyDevices.razor
+++ b/HomeAutomationBlazor/Components/Pages/PropertyDevices.razor
@@ -1,0 +1,166 @@
+@page "/properties/{id:int}"
+@rendermode InteractiveServer
+@inject ApiService Api
+
+<PageTitle>Property Devices</PageTitle>
+
+@if (!Api.IsAuthenticated)
+{
+    <p>Please <NavLink href="/login">log in</NavLink> to manage this property.</p>
+}
+else if (property == null)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <h3>@property.Name</h3>
+
+    <h4>Router Devices</h4>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Unique Id</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var r in routers)
+        {
+            <tr>
+                <td>@r.FriendlyName</td>
+                <td>@r.UniqueId</td>
+                <td>
+                    <button class="btn btn-sm btn-danger" @onclick="() => DeleteRouter(r.Id)">Delete</button>
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+    <EditForm Model="newRouter" OnValidSubmit="AddRouter">
+        <DataAnnotationsValidator />
+        <div class="row g-2 mb-3">
+            <div class="col">
+                <InputText class="form-control" placeholder="Name" @bind-Value="newRouter.FriendlyName" />
+            </div>
+            <div class="col">
+                <InputText class="form-control" placeholder="Unique Id" @bind-Value="newRouter.UniqueId" />
+            </div>
+            <div class="col-auto">
+                <button class="btn btn-primary" type="submit">Add</button>
+            </div>
+        </div>
+    </EditForm>
+
+    <h4 class="mt-4">Devices</h4>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Router</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var d in devices)
+        {
+            var routerName = routers.FirstOrDefault(r => r.Id == d.RouterDeviceId)?.FriendlyName ?? d.RouterDeviceId.ToString();
+            <tr>
+                <td>@d.Name</td>
+                <td>@routerName</td>
+                <td>
+                    <button class="btn btn-sm btn-danger" @onclick="() => DeleteDevice(d.Id)">Delete</button>
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+    <EditForm Model="newDevice" OnValidSubmit="AddDevice">
+        <DataAnnotationsValidator />
+        <div class="row g-2 mb-3">
+            <div class="col">
+                <InputText class="form-control" placeholder="Name" @bind-Value="newDevice.Name" />
+            </div>
+            <div class="col">
+                <InputSelect class="form-select" @bind-Value="newDevice.RouterDeviceId">
+                    <option value="0" disabled>Select router...</option>
+                    @foreach (var r in routers)
+                    {
+                        <option value="@r.Id">@r.FriendlyName</option>
+                    }
+                </InputSelect>
+            </div>
+            <div class="col-auto">
+                <button class="btn btn-primary" type="submit" disabled="@(newDevice.RouterDeviceId == 0)">Add</button>
+            </div>
+        </div>
+    </EditForm>
+}
+
+@code {
+    [Parameter]
+    public int id { get; set; }
+
+    private Property? property;
+    private List<RouterDevice> routers = new();
+    private RouterDevice newRouter = new();
+    private List<Device> devices = new();
+    private Device newDevice = new();
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (!Api.IsAuthenticated) return;
+
+        property = await Api.GetProperty(id);
+        var allRouters = await Api.GetRouterDevices();
+        routers = allRouters?.Where(r => r.PropertyId == id).ToList() ?? new();
+        var allDevices = await Api.GetDevices();
+        if (allDevices != null)
+        {
+            devices = allDevices.Where(d => routers.Any(r => r.Id == d.RouterDeviceId)).ToList();
+        }
+    }
+
+    private async Task AddRouter()
+    {
+        newRouter.PropertyId = id;
+        var created = await Api.CreateRouterDevice(newRouter);
+        if (created != null)
+        {
+            routers.Add(created);
+            newRouter = new RouterDevice();
+        }
+    }
+
+    private async Task DeleteRouter(int routerId)
+    {
+        await Api.DeleteRouterDevice(routerId);
+        devices.RemoveAll(d => d.RouterDeviceId == routerId);
+        var router = routers.FirstOrDefault(r => r.Id == routerId);
+        if (router != null)
+        {
+            routers.Remove(router);
+        }
+    }
+
+    private async Task AddDevice()
+    {
+        var created = await Api.CreateDevice(newDevice);
+        if (created != null)
+        {
+            devices.Add(created);
+            newDevice = new Device();
+        }
+    }
+
+    private async Task DeleteDevice(int id)
+    {
+        await Api.DeleteDevice(id);
+        var item = devices.FirstOrDefault(d => d.Id == id);
+        if (item != null)
+        {
+            devices.Remove(item);
+        }
+    }
+}

--- a/HomeAutomationBlazor/Components/_Imports.razor
+++ b/HomeAutomationBlazor/Components/_Imports.razor
@@ -11,3 +11,4 @@
 @using HomeAutomationBlazor.Services
 @using HomeAutomationBlazor.Models
 @using System.ComponentModel.DataAnnotations
+@using Microsoft.AspNetCore.Components

--- a/HomeAutomationBlazor/Models/Device.cs
+++ b/HomeAutomationBlazor/Models/Device.cs
@@ -1,0 +1,8 @@
+namespace HomeAutomationBlazor.Models;
+
+public class Device
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int RouterDeviceId { get; set; }
+}

--- a/HomeAutomationBlazor/Models/RouterDevice.cs
+++ b/HomeAutomationBlazor/Models/RouterDevice.cs
@@ -1,0 +1,9 @@
+namespace HomeAutomationBlazor.Models;
+
+public class RouterDevice
+{
+    public int Id { get; set; }
+    public string FriendlyName { get; set; } = string.Empty;
+    public string UniqueId { get; set; } = string.Empty;
+    public int PropertyId { get; set; }
+}

--- a/HomeAutomationBlazor/Services/ApiService.cs
+++ b/HomeAutomationBlazor/Services/ApiService.cs
@@ -44,6 +44,9 @@ public class ApiService
     public async Task<List<Property>?> GetProperties() =>
         await _http.GetFromJsonAsync<List<Property>>("api/properties");
 
+    public async Task<Property?> GetProperty(int id) =>
+        await _http.GetFromJsonAsync<Property>($"api/properties/{id}");
+
     public async Task<Property?> CreateProperty(Property prop)
     {
         var res = await _http.PostAsJsonAsync("api/properties", prop);
@@ -53,6 +56,32 @@ public class ApiService
 
     public async Task DeleteProperty(int id) =>
         await _http.DeleteAsync($"api/properties/{id}");
+
+    public async Task<List<RouterDevice>?> GetRouterDevices() =>
+        await _http.GetFromJsonAsync<List<RouterDevice>>("api/routerdevices");
+
+    public async Task<RouterDevice?> CreateRouterDevice(RouterDevice router)
+    {
+        var res = await _http.PostAsJsonAsync("api/routerdevices", router);
+        if (!res.IsSuccessStatusCode) return null;
+        return await res.Content.ReadFromJsonAsync<RouterDevice>();
+    }
+
+    public async Task DeleteRouterDevice(int id) =>
+        await _http.DeleteAsync($"api/routerdevices/{id}");
+
+    public async Task<List<Device>?> GetDevices() =>
+        await _http.GetFromJsonAsync<List<Device>>("api/devices");
+
+    public async Task<Device?> CreateDevice(Device dev)
+    {
+        var res = await _http.PostAsJsonAsync("api/devices", dev);
+        if (!res.IsSuccessStatusCode) return null;
+        return await res.Content.ReadFromJsonAsync<Device>();
+    }
+
+    public async Task DeleteDevice(int id) =>
+        await _http.DeleteAsync($"api/devices/{id}");
 
     private record TokenResponse(string token);
 


### PR DESCRIPTION
## Summary
- add router device and device models
- extend ApiService with device/router APIs
- manage routers and devices per property
- allow navigation from property list to new page
- import Microsoft.AspNetCore.Components for parameter usage

## Testing
- `dotnet build ZigbeeHomeAutomation.sln -v minimal` *(fails: SensorStateStore missing)*

------
https://chatgpt.com/codex/tasks/task_e_6862400b39f48321b2ea0e76e9f4034a