### PR TITLE
Fix navigation link markup

### DIFF
--- a/HomeAutomationBlazor/Components/Pages/Properties.razor
+++ b/HomeAutomationBlazor/Components/Pages/Properties.razor
@@ -34,7 +34,7 @@ else
                 <td>@p.RouterDeviceId</td>
                 <td>@p.OrganisationId</td>
                 <td>
-                    <NavLink class="btn btn-sm btn-secondary" href="/properties/@p.Id">Manage</NavLink>
+                    <NavLink class="btn btn-sm btn-secondary" href="@($"/properties/{p.Id}")">Manage</NavLink>
                 </td>
                 <td>
                     <button class="btn btn-sm btn-danger" @onclick="() => Delete(p.Id)">Delete</button>


### PR DESCRIPTION
## Summary
- fix navigation link markup in Properties page

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68701ccf5af483219df7aa094c03a4cd