### PR TITLE
Add admin user seeding

### DIFF
--- a/HomeAuthomationAPI/Data/SeedData.cs
+++ b/HomeAuthomationAPI/Data/SeedData.cs
@@ -1,0 +1,31 @@
+using HomeAuthomationAPI.Models;
+using Microsoft.AspNetCore.Identity;
+
+namespace HomeAuthomationAPI.Data;
+
+public static class SeedData
+{
+    public static void Initialize(HomeAutomationContext context)
+    {
+        // Ensure database is created
+        context.Database.EnsureCreated();
+
+        // Create default organisation if none exist
+        if (!context.Organisations.Any())
+        {
+            context.Organisations.Add(new Organisation { Name = "Default Organisation" });
+            context.SaveChanges();
+        }
+
+        // Create admin user if no users exist
+        if (!context.Users.Any())
+        {
+            var organisationId = context.Organisations.First().Id;
+            var admin = new User { Username = "admin", OrganisationId = organisationId };
+            var hasher = new PasswordHasher<User>();
+            admin.PasswordHash = hasher.HashPassword(admin, "admin");
+            context.Users.Add(admin);
+            context.SaveChanges();
+        }
+    }
+}

--- a/HomeAuthomationAPI/Program.cs
+++ b/HomeAuthomationAPI/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
+using Microsoft.Extensions.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -30,6 +31,14 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 builder.Services.AddAuthorization();
 
 var app = builder.Build();
+
+// Seed the database with default data
+using (var scope = app.Services.CreateScope())
+{
+    var services = scope.ServiceProvider;
+    var context = services.GetRequiredService<HomeAutomationContext>();
+    SeedData.Initialize(context);
+}
 
 // Enable Swagger middleware so that OpenAPI documentation is available
 // in all environments.


### PR DESCRIPTION
## Summary
- add SeedData for initializing default admin user
- register SeedData in program startup

## Testing
- `dotnet build HomeAuthomationAPI.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6876b27398088321a20f776a54705897