### PR TITLE
Add editing screens

### DIFF
--- a/HomeAutomationBlazor/Components/Pages/Organisations.razor
+++ b/HomeAutomationBlazor/Components/Pages/Organisations.razor
@@ -26,12 +26,28 @@ else
         <tbody>
         @foreach (var o in orgs)
         {
-            <tr>
-                <td>@o.Name</td>
-                <td>
-                    <button class="btn btn-sm btn-danger" @onclick="() => Delete(o.Id)">Delete</button>
-                </td>
-            </tr>
+            if (editOrg?.Id == o.Id)
+            {
+                <tr>
+                    <td>
+                        <InputText class="form-control" @bind-Value="editOrg.Name" />
+                    </td>
+                    <td>
+                        <button class="btn btn-sm btn-primary me-2" @onclick="SaveEdit">Save</button>
+                        <button class="btn btn-sm btn-secondary" @onclick="CancelEdit">Cancel</button>
+                    </td>
+                </tr>
+            }
+            else
+            {
+                <tr>
+                    <td>@o.Name</td>
+                    <td>
+                        <button class="btn btn-sm btn-secondary me-2" @onclick="() => StartEdit(o)">Edit</button>
+                        <button class="btn btn-sm btn-danger" @onclick="() => Delete(o.Id)">Delete</button>
+                    </td>
+                </tr>
+            }
         }
         </tbody>
     </table>
@@ -48,6 +64,7 @@ else
 @code {
     private List<Organisation>? orgs;
     private Organisation newOrg = new();
+    private Organisation? editOrg;
 
     protected override async Task OnInitializedAsync()
     {
@@ -76,4 +93,23 @@ else
             orgs!.Remove(item);
         }
     }
+
+    private void StartEdit(Organisation org)
+    {
+        editOrg = new Organisation { Id = org.Id, Name = org.Name };
+    }
+
+    private async Task SaveEdit()
+    {
+        if (editOrg == null) return;
+        await Api.UpdateOrganisation(editOrg);
+        var existing = orgs?.FirstOrDefault(o => o.Id == editOrg.Id);
+        if (existing != null)
+        {
+            existing.Name = editOrg.Name;
+        }
+        editOrg = null;
+    }
+
+    private void CancelEdit() => editOrg = null;
 }

--- a/HomeAutomationBlazor/Components/Pages/Properties.razor
+++ b/HomeAutomationBlazor/Components/Pages/Properties.razor
@@ -29,17 +29,34 @@ else
         <tbody>
         @foreach (var p in props)
         {
-            <tr>
-                <td>@p.Name</td>
-                <td>@p.RouterDeviceId</td>
-                <td>@p.OrganisationId</td>
-                <td>
-                    <NavLink class="btn btn-sm btn-secondary" href="@($"/properties/{p.Id}")">Manage</NavLink>
-                </td>
-                <td>
-                    <button class="btn btn-sm btn-danger" @onclick="() => Delete(p.Id)">Delete</button>
-                </td>
-            </tr>
+            if (editProp?.Id == p.Id)
+            {
+                <tr>
+                    <td><InputText class="form-control" @bind-Value="editProp.Name" /></td>
+                    <td><InputText class="form-control" @bind-Value="editProp.RouterDeviceId" /></td>
+                    <td><InputNumber class="form-control" @bind-Value="editProp.OrganisationId" /></td>
+                    <td>
+                        <button class="btn btn-sm btn-primary me-2" @onclick="SaveEdit">Save</button>
+                        <button class="btn btn-sm btn-secondary" @onclick="CancelEdit">Cancel</button>
+                    </td>
+                    <td></td>
+                </tr>
+            }
+            else
+            {
+                <tr>
+                    <td>@p.Name</td>
+                    <td>@p.RouterDeviceId</td>
+                    <td>@p.OrganisationId</td>
+                    <td>
+                        <NavLink class="btn btn-sm btn-secondary me-2" href="@($"/properties/{p.Id}")">Manage</NavLink>
+                        <button class="btn btn-sm btn-secondary" @onclick="() => StartEdit(p)">Edit</button>
+                    </td>
+                    <td>
+                        <button class="btn btn-sm btn-danger" @onclick="() => Delete(p.Id)">Delete</button>
+                    </td>
+                </tr>
+            }
         }
         </tbody>
     </table>
@@ -66,6 +83,7 @@ else
 @code {
     private List<Property>? props;
     private Property newProp = new();
+    private Property? editProp;
 
     protected override async Task OnInitializedAsync()
     {
@@ -94,4 +112,31 @@ else
             props!.Remove(item);
         }
     }
+
+    private void StartEdit(Property prop)
+    {
+        editProp = new Property
+        {
+            Id = prop.Id,
+            Name = prop.Name,
+            RouterDeviceId = prop.RouterDeviceId,
+            OrganisationId = prop.OrganisationId
+        };
+    }
+
+    private async Task SaveEdit()
+    {
+        if (editProp == null) return;
+        await Api.UpdateProperty(editProp);
+        var existing = props?.FirstOrDefault(p => p.Id == editProp.Id);
+        if (existing != null)
+        {
+            existing.Name = editProp.Name;
+            existing.RouterDeviceId = editProp.RouterDeviceId;
+            existing.OrganisationId = editProp.OrganisationId;
+        }
+        editProp = null;
+    }
+
+    private void CancelEdit() => editProp = null;
 }

--- a/HomeAutomationBlazor/Components/Pages/PropertyDevices.razor
+++ b/HomeAutomationBlazor/Components/Pages/PropertyDevices.razor
@@ -28,13 +28,28 @@ else
         <tbody>
         @foreach (var r in routers)
         {
-            <tr>
-                <td>@r.FriendlyName</td>
-                <td>@r.UniqueId</td>
-                <td>
-                    <button class="btn btn-sm btn-danger" @onclick="() => DeleteRouter(r.Id)">Delete</button>
-                </td>
-            </tr>
+            if (editRouter?.Id == r.Id)
+            {
+                <tr>
+                    <td><InputText class="form-control" @bind-Value="editRouter.FriendlyName" /></td>
+                    <td><InputText class="form-control" @bind-Value="editRouter.UniqueId" /></td>
+                    <td>
+                        <button class="btn btn-sm btn-primary me-2" @onclick="SaveRouterEdit">Save</button>
+                        <button class="btn btn-sm btn-secondary" @onclick="CancelRouterEdit">Cancel</button>
+                    </td>
+                </tr>
+            }
+            else
+            {
+                <tr>
+                    <td>@r.FriendlyName</td>
+                    <td>@r.UniqueId</td>
+                    <td>
+                        <button class="btn btn-sm btn-secondary me-2" @onclick="() => StartEditRouter(r)">Edit</button>
+                        <button class="btn btn-sm btn-danger" @onclick="() => DeleteRouter(r.Id)">Delete</button>
+                    </td>
+                </tr>
+            }
         }
         </tbody>
     </table>
@@ -66,13 +81,35 @@ else
         @foreach (var d in devices)
         {
             var routerName = routers.FirstOrDefault(r => r.Id == d.RouterDeviceId)?.FriendlyName ?? d.RouterDeviceId.ToString();
-            <tr>
-                <td>@d.Name</td>
-                <td>@routerName</td>
-                <td>
-                    <button class="btn btn-sm btn-danger" @onclick="() => DeleteDevice(d.Id)">Delete</button>
-                </td>
-            </tr>
+            if (editDevice?.Id == d.Id)
+            {
+                <tr>
+                    <td><InputText class="form-control" @bind-Value="editDevice.Name" /></td>
+                    <td>
+                        <InputSelect class="form-select" @bind-Value="editDevice.RouterDeviceId">
+                            @foreach (var r in routers)
+                            {
+                                <option value="@r.Id">@r.FriendlyName</option>
+                            }
+                        </InputSelect>
+                    </td>
+                    <td>
+                        <button class="btn btn-sm btn-primary me-2" @onclick="SaveDeviceEdit">Save</button>
+                        <button class="btn btn-sm btn-secondary" @onclick="CancelDeviceEdit">Cancel</button>
+                    </td>
+                </tr>
+            }
+            else
+            {
+                <tr>
+                    <td>@d.Name</td>
+                    <td>@routerName</td>
+                    <td>
+                        <button class="btn btn-sm btn-secondary me-2" @onclick="() => StartEditDevice(d)">Edit</button>
+                        <button class="btn btn-sm btn-danger" @onclick="() => DeleteDevice(d.Id)">Delete</button>
+                    </td>
+                </tr>
+            }
         }
         </tbody>
     </table>
@@ -105,8 +142,10 @@ else
     private Property? property;
     private List<RouterDevice> routers = new();
     private RouterDevice newRouter = new();
+    private RouterDevice? editRouter;
     private List<Device> devices = new();
     private Device newDevice = new();
+    private Device? editDevice;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -144,6 +183,32 @@ else
         }
     }
 
+    private void StartEditRouter(RouterDevice router)
+    {
+        editRouter = new RouterDevice
+        {
+            Id = router.Id,
+            FriendlyName = router.FriendlyName,
+            UniqueId = router.UniqueId,
+            PropertyId = router.PropertyId
+        };
+    }
+
+    private async Task SaveRouterEdit()
+    {
+        if (editRouter == null) return;
+        await Api.UpdateRouterDevice(editRouter);
+        var existing = routers.FirstOrDefault(r => r.Id == editRouter.Id);
+        if (existing != null)
+        {
+            existing.FriendlyName = editRouter.FriendlyName;
+            existing.UniqueId = editRouter.UniqueId;
+        }
+        editRouter = null;
+    }
+
+    private void CancelRouterEdit() => editRouter = null;
+
     private async Task AddDevice()
     {
         var created = await Api.CreateDevice(newDevice);
@@ -163,4 +228,29 @@ else
             devices.Remove(item);
         }
     }
+
+    private void StartEditDevice(Device dev)
+    {
+        editDevice = new Device
+        {
+            Id = dev.Id,
+            Name = dev.Name,
+            RouterDeviceId = dev.RouterDeviceId
+        };
+    }
+
+    private async Task SaveDeviceEdit()
+    {
+        if (editDevice == null) return;
+        await Api.UpdateDevice(editDevice);
+        var existing = devices.FirstOrDefault(d => d.Id == editDevice.Id);
+        if (existing != null)
+        {
+            existing.Name = editDevice.Name;
+            existing.RouterDeviceId = editDevice.RouterDeviceId;
+        }
+        editDevice = null;
+    }
+
+    private void CancelDeviceEdit() => editDevice = null;
 }

--- a/HomeAutomationBlazor/Services/ApiService.cs
+++ b/HomeAutomationBlazor/Services/ApiService.cs
@@ -38,6 +38,11 @@ public class ApiService
         return await res.Content.ReadFromJsonAsync<Organisation>();
     }
 
+    public async Task UpdateOrganisation(Organisation org)
+    {
+        await _http.PutAsJsonAsync($"api/organisations/{org.Id}", org);
+    }
+
     public async Task DeleteOrganisation(int id) =>
         await _http.DeleteAsync($"api/organisations/{id}");
 
@@ -54,6 +59,11 @@ public class ApiService
         return await res.Content.ReadFromJsonAsync<Property>();
     }
 
+    public async Task UpdateProperty(Property prop)
+    {
+        await _http.PutAsJsonAsync($"api/properties/{prop.Id}", prop);
+    }
+
     public async Task DeleteProperty(int id) =>
         await _http.DeleteAsync($"api/properties/{id}");
 
@@ -67,6 +77,11 @@ public class ApiService
         return await res.Content.ReadFromJsonAsync<RouterDevice>();
     }
 
+    public async Task UpdateRouterDevice(RouterDevice router)
+    {
+        await _http.PutAsJsonAsync($"api/routerdevices/{router.Id}", router);
+    }
+
     public async Task DeleteRouterDevice(int id) =>
         await _http.DeleteAsync($"api/routerdevices/{id}");
 
@@ -78,6 +93,11 @@ public class ApiService
         var res = await _http.PostAsJsonAsync("api/devices", dev);
         if (!res.IsSuccessStatusCode) return null;
         return await res.Content.ReadFromJsonAsync<Device>();
+    }
+
+    public async Task UpdateDevice(Device dev)
+    {
+        await _http.PutAsJsonAsync($"api/devices/{dev.Id}", dev);
     }
 
     public async Task DeleteDevice(int id) =>


### PR DESCRIPTION
## Summary
- add `Update*` methods for all entity types in `ApiService`
- allow editing organisations inline
- allow editing properties inline
- add editing for router devices and devices within a property

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876d0e82bd483219c35b9bad32a67e5