### PR TITLE
Make API base address configurable

### DIFF
--- a/HomeAutomationBlazor/Program.cs
+++ b/HomeAutomationBlazor/Program.cs
@@ -15,7 +15,7 @@ public class Program
 
         builder.Services.AddHttpClient<ApiService>(client =>
         {
-            client.BaseAddress = new Uri(builder.Configuration["ApiBaseAddress"] ?? "http://localhost:5000/");
+            client.BaseAddress = new Uri(builder.Configuration["ApiBaseAddress"] ?? "https://localhost:7119/");
         });
 
         var app = builder.Build();

--- a/HomeAutomationBlazor/appsettings.Development.json
+++ b/HomeAutomationBlazor/appsettings.Development.json
@@ -5,5 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "ApiBaseAddress": "https://localhost:5001/"
+  "ApiBaseAddress": "https://localhost:7119/"
 }

--- a/HomeAutomationBlazor/appsettings.json
+++ b/HomeAutomationBlazor/appsettings.json
@@ -6,5 +6,5 @@
     }
   },
   "AllowedHosts": "*",
-  "ApiBaseAddress": "https://localhost:5001/"
+  "ApiBaseAddress": "https://localhost:7119/"
 }


### PR DESCRIPTION
## Summary
- update Blazor app configuration to use `https://localhost:7119/`
- default API base address in `Program.cs` to the same value

## Testing
- `apt-get update -y` *(fails: mise.jdx.dev blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687762b892948321be06e2fea1e3057d