### PR TITLE
Fix login state persistence

### DIFF
--- a/HomeAutomationBlazor/Program.cs
+++ b/HomeAutomationBlazor/Program.cs
@@ -13,9 +13,15 @@ public class Program
         builder.Services.AddRazorComponents()
             .AddInteractiveServerComponents();
 
-        builder.Services.AddHttpClient<ApiService>(client =>
+        builder.Services.AddHttpClient("Api", client =>
         {
             client.BaseAddress = new Uri(builder.Configuration["ApiBaseAddress"] ?? "https://localhost:7119/");
+        });
+
+        builder.Services.AddScoped<ApiService>(sp =>
+        {
+            var factory = sp.GetRequiredService<IHttpClientFactory>();
+            return new ApiService(factory.CreateClient("Api"));
         });
 
         var app = builder.Build();


### PR DESCRIPTION
## Summary
- ensure `ApiService` is scoped so login token survives navigation

## Testing
- `dotnet build HomeAutomationBlazor/HomeAutomationBlazor.csproj -clp:ErrorsOnly`


------
https://chatgpt.com/codex/tasks/task_e_68776ef226dc8321b444a1841c82caf8