### PR TITLE
Handle HTTP failures in client

### DIFF
--- a/HomeAutomationBlazor/Components/Pages/Organisations.razor
+++ b/HomeAutomationBlazor/Components/Pages/Organisations.razor
@@ -70,7 +70,7 @@ else
     {
         if (Api.IsAuthenticated)
         {
-            orgs = await Api.GetOrganisations();
+            orgs = await Api.GetOrganisations() ?? new List<Organisation>();
         }
     }
 

--- a/HomeAutomationBlazor/Services/ApiService.cs
+++ b/HomeAutomationBlazor/Services/ApiService.cs
@@ -28,8 +28,18 @@ public class ApiService
         return true;
     }
 
-    public async Task<List<Organisation>?> GetOrganisations() =>
-        await _http.GetFromJsonAsync<List<Organisation>>("api/organisations");
+    public async Task<List<Organisation>?> GetOrganisations()
+    {
+        try
+        {
+            return await _http.GetFromJsonAsync<List<Organisation>>("api/organisations");
+        }
+        catch (HttpRequestException ex)
+        {
+            Console.Error.WriteLine($"Error fetching organisations: {ex.Message}");
+            return null;
+        }
+    }
 
     public async Task<Organisation?> CreateOrganisation(Organisation org)
     {


### PR DESCRIPTION
## Summary
- add error handling when fetching organisations
- avoid crash when organisations fetch fails

## Testing
- `dotnet build HomeAutomationBlazor/HomeAutomationBlazor.csproj`
- `dotnet test ZigbeeHomeAutomation.sln` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687770787abc8321a2cf635e0622bb8b