### PR TITLE
Improve error handling UI

### DIFF
--- a/HomeAutomationBlazor/Components/ErrorDisplay.razor
+++ b/HomeAutomationBlazor/Components/ErrorDisplay.razor
@@ -1,0 +1,15 @@
+@if (Error != null)
+{
+    <div class="alert alert-danger" role="alert">
+        <p>@Error.Message</p>
+        <button class="btn btn-link" @onclick="OnDismiss">Dismiss</button>
+    </div>
+}
+
+@code {
+    [Parameter]
+    public Exception? Error { get; set; }
+
+    [Parameter]
+    public EventCallback OnDismiss { get; set; }
+}

--- a/HomeAutomationBlazor/Components/Layout/MainLayout.razor
+++ b/HomeAutomationBlazor/Components/Layout/MainLayout.razor
@@ -11,13 +11,24 @@
         </div>
 
         <article class="content px-4">
-            @Body
+            <ErrorBoundary @ref="errorBoundary">
+                <ChildContent>
+                    @Body
+                </ChildContent>
+                <ErrorContent>
+                    <ErrorDisplay Error="context" OnDismiss="Recover" />
+                </ErrorContent>
+            </ErrorBoundary>
         </article>
     </main>
 </div>
 
-<div id="blazor-error-ui">
-    An unhandled error has occurred.
-    <a href="" class="reload">Reload</a>
-    <a class="dismiss">🗙</a>
-</div>
+@code {
+    private ErrorBoundary? errorBoundary;
+
+    private void Recover()
+    {
+        errorBoundary?.Recover();
+    }
+}
+

--- a/HomeAutomationBlazor/Components/Pages/Login.razor
+++ b/HomeAutomationBlazor/Components/Pages/Login.razor
@@ -38,7 +38,7 @@
         }
         else
         {
-            error = "Invalid username or password";
+            error = Api.LastError ?? "Invalid username or password";
         }
     }
 


### PR DESCRIPTION
## Summary
- show a custom error boundary inside `MainLayout`
- display exceptions with `ErrorDisplay` component
- surface API error messages during login

## Testing
- `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877719bd0ac83218b2f515b12f32412