### PR TITLE
Add users management page

### DIFF
--- a/HomeAutomationBlazor/Components/Layout/NavMenu.razor
+++ b/HomeAutomationBlazor/Components/Layout/NavMenu.razor
@@ -49,6 +49,12 @@
                 <span class="bi bi-sliders-nav-menu" aria-hidden="true"></span> Configurations
             </NavLink>
         </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="users">
+                <span class="bi bi-people" aria-hidden="true"></span> Users
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/HomeAutomationBlazor/Components/Pages/Users.razor
+++ b/HomeAutomationBlazor/Components/Pages/Users.razor
@@ -1,0 +1,153 @@
+@page "/users"
+@rendermode InteractiveServer
+@inject ApiService Api
+
+<PageTitle>Users</PageTitle>
+
+<h3>Users</h3>
+
+@if (!Api.IsAuthenticated)
+{
+    <p>Please <NavLink href="/login">log in</NavLink> to manage users.</p>
+}
+else if (users == null || orgs == null)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Username</th>
+                <th>Organisation</th>
+                <th></th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var u in users)
+        {
+            var orgName = orgs.FirstOrDefault(o => o.Id == u.OrganisationId)?.Name ?? u.OrganisationId.ToString();
+            if (editUser?.Id == u.Id)
+            {
+                <tr>
+                    <td><InputText class="form-control" @bind-Value="editUser.Username" /></td>
+                    <td>
+                        <InputSelect class="form-select" @bind-Value="editUser.OrganisationId">
+                            @foreach (var o in orgs)
+                            {
+                                <option value="@o.Id">@o.Name</option>
+                            }
+                        </InputSelect>
+                    </td>
+                    <td>
+                        <button class="btn btn-sm btn-primary me-2" @onclick="SaveEdit">Save</button>
+                        <button class="btn btn-sm btn-secondary" @onclick="CancelEdit">Cancel</button>
+                    </td>
+                    <td></td>
+                </tr>
+            }
+            else
+            {
+                <tr>
+                    <td>@u.Username</td>
+                    <td>@orgName</td>
+                    <td>
+                        <button class="btn btn-sm btn-secondary me-2" @onclick="() => StartEdit(u)">Edit</button>
+                    </td>
+                    <td>
+                        <button class="btn btn-sm btn-danger" @onclick="() => Delete(u.Id)">Delete</button>
+                    </td>
+                </tr>
+            }
+        }
+        </tbody>
+    </table>
+
+    <EditForm Model="newUser" OnValidSubmit="AddUser">
+        <DataAnnotationsValidator />
+        <div class="row g-2 mb-3">
+            <div class="col">
+                <InputText class="form-control" placeholder="Username" @bind-Value="newUser.Username" />
+            </div>
+            <div class="col">
+                <InputText type="password" class="form-control" placeholder="Password" @bind-Value="newUser.PasswordHash" />
+            </div>
+            <div class="col">
+                <InputSelect class="form-select" @bind-Value="newUser.OrganisationId">
+                    <option value="0" disabled>Select organisation...</option>
+                    @foreach (var o in orgs)
+                    {
+                        <option value="@o.Id">@o.Name</option>
+                    }
+                </InputSelect>
+            </div>
+            <div class="col-auto">
+                <button class="btn btn-primary" type="submit" disabled="@(newUser.OrganisationId == 0)">Add</button>
+            </div>
+        </div>
+    </EditForm>
+}
+
+@code {
+    private List<User>? users;
+    private List<Organisation>? orgs;
+    private User newUser = new();
+    private User? editUser;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (Api.IsAuthenticated)
+        {
+            users = await Api.GetUsers() ?? new List<User>();
+            orgs = await Api.GetOrganisations() ?? new List<Organisation>();
+        }
+    }
+
+    private async Task AddUser()
+    {
+        var created = await Api.CreateUser(newUser);
+        if (created != null)
+        {
+            users!.Add(created);
+            newUser = new User();
+        }
+    }
+
+    private async Task Delete(int id)
+    {
+        await Api.DeleteUser(id);
+        var item = users?.FirstOrDefault(u => u.Id == id);
+        if (item != null)
+        {
+            users!.Remove(item);
+        }
+    }
+
+    private void StartEdit(User u)
+    {
+        editUser = new User
+        {
+            Id = u.Id,
+            Username = u.Username,
+            PasswordHash = u.PasswordHash,
+            OrganisationId = u.OrganisationId
+        };
+    }
+
+    private async Task SaveEdit()
+    {
+        if (editUser == null) return;
+        await Api.UpdateUser(editUser);
+        var existing = users?.FirstOrDefault(u => u.Id == editUser.Id);
+        if (existing != null)
+        {
+            existing.Username = editUser.Username;
+            existing.OrganisationId = editUser.OrganisationId;
+        }
+        editUser = null;
+    }
+
+    private void CancelEdit() => editUser = null;
+}

--- a/HomeAutomationBlazor/Models/User.cs
+++ b/HomeAutomationBlazor/Models/User.cs
@@ -1,0 +1,9 @@
+namespace HomeAutomationBlazor.Models;
+
+public class User
+{
+    public int Id { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string PasswordHash { get; set; } = string.Empty;
+    public int OrganisationId { get; set; }
+}

--- a/HomeAutomationBlazor/Services/ApiService.cs
+++ b/HomeAutomationBlazor/Services/ApiService.cs
@@ -144,6 +144,24 @@ public class ApiService
     public async Task DeleteConfiguration(int id) =>
         await _http.DeleteAsync($"api/configurations/{id}");
 
+    public async Task<List<User>?> GetUsers() =>
+        await _http.GetFromJsonAsync<List<User>>("api/users");
+
+    public async Task<User?> CreateUser(User user)
+    {
+        var res = await _http.PostAsJsonAsync("api/users", user);
+        if (!res.IsSuccessStatusCode) return null;
+        return await res.Content.ReadFromJsonAsync<User>();
+    }
+
+    public async Task UpdateUser(User user)
+    {
+        await _http.PutAsJsonAsync($"api/users/{user.Id}", user);
+    }
+
+    public async Task DeleteUser(int id) =>
+        await _http.DeleteAsync($"api/users/{id}");
+
     private record TokenResponse(string token);
 
     public void Logout()


### PR DESCRIPTION
## Summary
- implement `User` model and API service helpers
- add new *Users* page for listing and editing users
- expose the page in the nav menu

## Testing
- `dotnet build HomeAuthomationAPI.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877748b060c8321832e18c561624f96