### PR TITLE
Link router devices and organisations in Blazor

### DIFF
--- a/HomeAutomationBlazor/Components/Layout/NavMenu.razor
+++ b/HomeAutomationBlazor/Components/Layout/NavMenu.razor
@@ -45,6 +45,12 @@
         </div>
 
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="routerdevices">
+                <span class="bi bi-hdd-network" aria-hidden="true"></span> Router Devices
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="configurations">
                 <span class="bi bi-sliders-nav-menu" aria-hidden="true"></span> Configurations
             </NavLink>

--- a/HomeAutomationBlazor/Components/Pages/Configurations.razor
+++ b/HomeAutomationBlazor/Components/Pages/Configurations.razor
@@ -30,9 +30,10 @@ else
         @foreach (var c in configs)
         {
             var cfg = ParseConfig(c.Content);
+            var routerName = routers?.FirstOrDefault(r => r.UniqueId == cfg.RouterDeviceId)?.FriendlyName ?? cfg.RouterDeviceId;
             <tr>
                 <td>@cfg.ConfigurationName</td>
-                <td>@cfg.RouterDeviceId</td>
+                <td>@routerName</td>
                 <td>
                     <button class="btn btn-sm btn-secondary" @onclick="() => Edit(c)">Edit</button>
                 </td>
@@ -58,7 +59,7 @@ else
                 <label class="form-label">Router</label>
                 <InputSelect class="form-select" @bind-Value="editingContent.RouterDeviceId">
                     <option value="">Select router...</option>
-                    @foreach (var r in routers)
+                    @foreach (var r in routers ?? Enumerable.Empty<RouterDevice>())
                     {
                         <option value="@r.UniqueId">@r.FriendlyName</option>
                     }
@@ -289,6 +290,7 @@ else
     {
         editing = new Configuration();
         editingContent = new AutomationConfiguration { ConfigurationDate = DateTime.Now };
+        editingContent.RouterDeviceId = string.Empty;
         editingContent.Rules.Add(new Rule());
         currentRuleIndex = 0;
         activeTab = 0;
@@ -298,6 +300,14 @@ else
     {
         editing = config;
         editingContent = ParseConfig(config.Content);
+        if (config.RouterDeviceId.HasValue)
+        {
+            var router = routers?.FirstOrDefault(r => r.Id == config.RouterDeviceId.Value);
+            if (router != null)
+            {
+                editingContent.RouterDeviceId = router.UniqueId;
+            }
+        }
         if (editingContent.Rules.Count == 0)
         {
             editingContent.Rules.Add(new Rule());
@@ -309,6 +319,8 @@ else
     private async Task SaveConfig()
     {
         editing!.Content = System.Text.Json.JsonSerializer.Serialize(editingContent);
+        var router = routers?.FirstOrDefault(r => r.UniqueId == editingContent.RouterDeviceId);
+        editing.RouterDeviceId = router?.Id;
         if (editing.Id == 0)
         {
             var created = await Api.CreateConfiguration(editing);

--- a/HomeAutomationBlazor/Components/Pages/Properties.razor
+++ b/HomeAutomationBlazor/Components/Pages/Properties.razor
@@ -34,7 +34,17 @@ else
                 <tr>
                     <td><InputText class="form-control" @bind-Value="editProp.Name" /></td>
                     <td><InputText class="form-control" @bind-Value="editProp.RouterDeviceId" /></td>
-                    <td><InputNumber class="form-control" @bind-Value="editProp.OrganisationId" /></td>
+                    <td>
+                        <InputSelect class="form-select" @bind-Value="editProp.OrganisationId">
+                            @if (organisations != null)
+                            {
+                                @foreach (var o in organisations)
+                                {
+                                    <option value="@o.Id">@o.Name</option>
+                                }
+                            }
+                        </InputSelect>
+                    </td>
                     <td>
                         <button class="btn btn-sm btn-primary me-2" @onclick="SaveEdit">Save</button>
                         <button class="btn btn-sm btn-secondary" @onclick="CancelEdit">Cancel</button>
@@ -47,7 +57,7 @@ else
                 <tr>
                     <td>@p.Name</td>
                     <td>@p.RouterDeviceId</td>
-                    <td>@p.OrganisationId</td>
+                    <td>@(organisations?.FirstOrDefault(o => o.Id == p.OrganisationId)?.Name ?? p.OrganisationId.ToString())</td>
                     <td>
                         <NavLink class="btn btn-sm btn-secondary me-2" href="@($"/properties/{p.Id}")">Manage</NavLink>
                         <button class="btn btn-sm btn-secondary" @onclick="() => StartEdit(p)">Edit</button>
@@ -71,7 +81,16 @@ else
                 <InputText class="form-control" placeholder="Router" @bind-Value="newProp.RouterDeviceId" />
             </div>
             <div class="col">
-                <InputNumber class="form-control" @bind-Value="newProp.OrganisationId" />
+                <InputSelect class="form-select" @bind-Value="newProp.OrganisationId">
+                    <option value="0" disabled>Select organisation...</option>
+                    @if (organisations != null)
+                    {
+                        @foreach (var o in organisations)
+                        {
+                            <option value="@o.Id">@o.Name</option>
+                        }
+                    }
+                </InputSelect>
             </div>
             <div class="col-auto">
                 <button class="btn btn-primary" type="submit">Add</button>
@@ -82,6 +101,7 @@ else
 
 @code {
     private List<Property>? props;
+    private List<Organisation>? organisations;
     private Property newProp = new();
     private Property? editProp;
 
@@ -90,6 +110,7 @@ else
         if (Api.IsAuthenticated)
         {
             props = await Api.GetProperties();
+            organisations = await Api.GetOrganisations();
         }
     }
 

--- a/HomeAutomationBlazor/Components/Pages/RouterDevices.razor
+++ b/HomeAutomationBlazor/Components/Pages/RouterDevices.razor
@@ -1,0 +1,153 @@
+@page "/routerdevices"
+@rendermode InteractiveServer
+@inject ApiService Api
+
+<PageTitle>Router Devices</PageTitle>
+
+<h3>Router Devices</h3>
+
+@if (!Api.IsAuthenticated)
+{
+    <p>Please <NavLink href="/login">log in</NavLink> to manage router devices.</p>
+}
+else if (routers == null || properties == null)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Unique Id</th>
+                <th>Property</th>
+                <th></th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var r in routers)
+        {
+            var propName = properties.FirstOrDefault(p => p.Id == r.PropertyId)?.Name ?? r.PropertyId.ToString();
+            if (editRouter?.Id == r.Id)
+            {
+                <tr>
+                    <td><InputText class="form-control" @bind-Value="editRouter.FriendlyName" /></td>
+                    <td><InputText class="form-control" @bind-Value="editRouter.UniqueId" /></td>
+                    <td>
+                        <InputSelect class="form-select" @bind-Value="editRouter.PropertyId">
+                            @foreach (var p in properties)
+                            {
+                                <option value="@p.Id">@p.Name</option>
+                            }
+                        </InputSelect>
+                    </td>
+                    <td>
+                        <button class="btn btn-sm btn-primary me-2" @onclick="SaveEdit">Save</button>
+                        <button class="btn btn-sm btn-secondary" @onclick="CancelEdit">Cancel</button>
+                    </td>
+                    <td></td>
+                </tr>
+            }
+            else
+            {
+                <tr>
+                    <td>@r.FriendlyName</td>
+                    <td>@r.UniqueId</td>
+                    <td>@propName</td>
+                    <td>
+                        <button class="btn btn-sm btn-secondary me-2" @onclick="() => StartEdit(r)">Edit</button>
+                    </td>
+                    <td>
+                        <button class="btn btn-sm btn-danger" @onclick="() => DeleteRouter(r.Id)">Delete</button>
+                    </td>
+                </tr>
+            }
+        }
+        </tbody>
+    </table>
+
+    <EditForm Model="newRouter" OnValidSubmit="AddRouter">
+        <DataAnnotationsValidator />
+        <div class="row g-2 mb-3">
+            <div class="col">
+                <InputText class="form-control" placeholder="Name" @bind-Value="newRouter.FriendlyName" />
+            </div>
+            <div class="col">
+                <InputText class="form-control" placeholder="Unique Id" @bind-Value="newRouter.UniqueId" />
+            </div>
+            <div class="col">
+                <InputSelect class="form-select" @bind-Value="newRouter.PropertyId">
+                    <option value="0" disabled>Select property...</option>
+                    @foreach (var p in properties)
+                    {
+                        <option value="@p.Id">@p.Name</option>
+                    }
+                </InputSelect>
+            </div>
+            <div class="col-auto">
+                <button class="btn btn-primary" type="submit" disabled="@(newRouter.PropertyId == 0)">Add</button>
+            </div>
+        </div>
+    </EditForm>
+}
+
+@code {
+    private List<RouterDevice>? routers;
+    private List<Property>? properties;
+    private RouterDevice newRouter = new();
+    private RouterDevice? editRouter;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (Api.IsAuthenticated)
+        {
+            routers = await Api.GetRouterDevices();
+            properties = await Api.GetProperties();
+        }
+    }
+
+    private async Task AddRouter()
+    {
+        var created = await Api.CreateRouterDevice(newRouter);
+        if (created != null)
+        {
+            routers!.Add(created);
+            newRouter = new RouterDevice();
+        }
+    }
+
+    private async Task DeleteRouter(int id)
+    {
+        await Api.DeleteRouterDevice(id);
+        routers?.RemoveAll(r => r.Id == id);
+    }
+
+    private void StartEdit(RouterDevice router)
+    {
+        editRouter = new RouterDevice
+        {
+            Id = router.Id,
+            FriendlyName = router.FriendlyName,
+            UniqueId = router.UniqueId,
+            PropertyId = router.PropertyId
+        };
+    }
+
+    private async Task SaveEdit()
+    {
+        if (editRouter == null) return;
+        await Api.UpdateRouterDevice(editRouter);
+        var existing = routers?.FirstOrDefault(r => r.Id == editRouter.Id);
+        if (existing != null)
+        {
+            existing.FriendlyName = editRouter.FriendlyName;
+            existing.UniqueId = editRouter.UniqueId;
+            existing.PropertyId = editRouter.PropertyId;
+        }
+        editRouter = null;
+    }
+
+    private void CancelEdit() => editRouter = null;
+}


### PR DESCRIPTION
## Summary
- allow choosing organisation when creating or editing a Property
- show organisation names in the properties list
- add Router Devices page for managing router devices and linking them to properties
- enable selecting routers when editing Configurations and persist the router relationship
- add Router Devices link to navigation menu

## Testing
- `dotnet build HomeAutomationBlazor/HomeAutomationBlazor.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68777638eb7083218ed538d610f4a061