### PR TITLE
Restrict data visibility to organisation

### DIFF
--- a/HomeAuthomationAPI/Controllers/BaseController.cs
+++ b/HomeAuthomationAPI/Controllers/BaseController.cs
@@ -1,0 +1,37 @@
+using HomeAuthomationAPI.Data;
+using HomeAuthomationAPI.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace HomeAuthomationAPI.Controllers
+{
+    [Authorize]
+    public abstract class BaseController : ControllerBase
+    {
+        protected readonly HomeAutomationContext _context;
+
+        protected BaseController(HomeAutomationContext context)
+        {
+            _context = context;
+        }
+
+        protected int? CurrentUserId
+        {
+            get
+            {
+                var idClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+                return int.TryParse(idClaim, out var id) ? id : null;
+            }
+        }
+
+        protected bool IsGlobalAdmin => User.IsInRole("GlobalAdmin");
+
+        protected async Task<User?> GetCurrentUserAsync()
+        {
+            var id = CurrentUserId;
+            if (id == null) return null;
+            return await _context.Users.FindAsync(id.Value);
+        }
+    }
+}

--- a/HomeAuthomationAPI/Controllers/ConfigurationsController.cs
+++ b/HomeAuthomationAPI/Controllers/ConfigurationsController.cs
@@ -1,31 +1,68 @@
 using HomeAuthomationAPI.Data;
 using HomeAuthomationAPI.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System.Linq;
 
 namespace HomeAuthomationAPI.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    public class ConfigurationsController : ControllerBase
+    [Authorize]
+    public class ConfigurationsController : BaseController
     {
-        private readonly HomeAutomationContext _context;
-        public ConfigurationsController(HomeAutomationContext context)
+        public ConfigurationsController(HomeAutomationContext context) : base(context)
         {
-            _context = context;
         }
 
         [HttpGet]
         public async Task<ActionResult<IEnumerable<Configuration>>> Get()
         {
-            return await _context.Configurations.ToListAsync();
+            IQueryable<Configuration> query = _context.Configurations
+                .Include(c => c.Property)
+                .Include(c => c.RouterDevice)
+                .Include(c => c.Device)
+                    .ThenInclude(d => d.RouterDevice)
+                        .ThenInclude(r => r.Property);
+
+            if (!IsGlobalAdmin)
+            {
+                var user = await GetCurrentUserAsync();
+                if (user == null) return Forbid();
+                query = query.Where(c =>
+                    (c.Property != null && c.Property.OrganisationId == user.OrganisationId) ||
+                    (c.RouterDevice != null && c.RouterDevice.Property!.OrganisationId == user.OrganisationId) ||
+                    (c.Device != null && c.Device.RouterDevice!.Property!.OrganisationId == user.OrganisationId));
+            }
+
+            return await query.ToListAsync();
         }
 
         [HttpGet("{id}")]
         public async Task<ActionResult<Configuration>> Get(int id)
         {
-            var config = await _context.Configurations.FindAsync(id);
+            var config = await _context.Configurations
+                .Include(c => c.Property)
+                .Include(c => c.RouterDevice)
+                .Include(c => c.Device)
+                    .ThenInclude(d => d.RouterDevice)
+                        .ThenInclude(r => r.Property)
+                .FirstOrDefaultAsync(c => c.Id == id);
             if (config == null) return NotFound();
+
+            if (!IsGlobalAdmin)
+            {
+                var user = await GetCurrentUserAsync();
+                if (user == null ||
+                    !((config.Property != null && config.Property.OrganisationId == user.OrganisationId) ||
+                      (config.RouterDevice != null && config.RouterDevice.Property!.OrganisationId == user.OrganisationId) ||
+                      (config.Device != null && config.Device.RouterDevice!.Property!.OrganisationId == user.OrganisationId)))
+                {
+                    return Forbid();
+                }
+            }
+
             return config;
         }
 

--- a/HomeAuthomationAPI/Controllers/PropertiesController.cs
+++ b/HomeAuthomationAPI/Controllers/PropertiesController.cs
@@ -1,31 +1,51 @@
 using HomeAuthomationAPI.Data;
 using HomeAuthomationAPI.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System.Linq;
 
 namespace HomeAuthomationAPI.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    public class PropertiesController : ControllerBase
+    [Authorize]
+    public class PropertiesController : BaseController
     {
-        private readonly HomeAutomationContext _context;
-        public PropertiesController(HomeAutomationContext context)
+        public PropertiesController(HomeAutomationContext context) : base(context)
         {
-            _context = context;
         }
 
         [HttpGet]
         public async Task<ActionResult<IEnumerable<Property>>> Get()
         {
-            return await _context.Properties.Include(p => p.Configuration).ToListAsync();
+            IQueryable<Property> query = _context.Properties.Include(p => p.Configuration);
+
+            if (!IsGlobalAdmin)
+            {
+                var user = await GetCurrentUserAsync();
+                if (user == null) return Forbid();
+                query = query.Where(p => p.OrganisationId == user.OrganisationId);
+            }
+
+            return await query.ToListAsync();
         }
 
         [HttpGet("{id}")]
         public async Task<ActionResult<Property>> Get(int id)
         {
-            var property = await _context.Properties.Include(p => p.Configuration).FirstOrDefaultAsync(p => p.Id == id);
+            var property = await _context.Properties
+                .Include(p => p.Configuration)
+                .FirstOrDefaultAsync(p => p.Id == id);
             if (property == null) return NotFound();
+
+            if (!IsGlobalAdmin)
+            {
+                var user = await GetCurrentUserAsync();
+                if (user == null || property.OrganisationId != user.OrganisationId)
+                    return Forbid();
+            }
+
             return property;
         }
 


### PR DESCRIPTION
## Summary
- introduce `BaseController` for shared user helpers
- require authorization and filter organisation-related data in various controllers

## Testing
- `dotnet build HomeAuthomationAPI.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0 or 8.0)*

------
https://chatgpt.com/codex/tasks/task_e_687778970fe48321a43408213f48b0e3