### PR TITLE
Implement organization dropdown population on Properties page

### DIFF
--- a/HomeAutomationBlazor/Components/Pages/Properties.razor
+++ b/HomeAutomationBlazor/Components/Pages/Properties.razor
@@ -1,6 +1,7 @@
 @page "/properties"
 @rendermode InteractiveServer
 @inject ApiService Api
+@implements IDisposable
 
 <PageTitle>Properties</PageTitle>
 
@@ -107,11 +108,32 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        Api.AuthStateChanged += OnAuthChanged;
         if (Api.IsAuthenticated)
         {
-            props = await Api.GetProperties();
-            organisations = await Api.GetOrganisations();
+            await LoadDataAsync();
         }
+    }
+
+    private async void OnAuthChanged()
+    {
+        if (Api.IsAuthenticated)
+        {
+            await LoadDataAsync();
+        }
+        else
+        {
+            props = null;
+            organisations = null;
+            StateHasChanged();
+        }
+    }
+
+    private async Task LoadDataAsync()
+    {
+        props = await Api.GetProperties();
+        organisations = await Api.GetOrganisations();
+        StateHasChanged();
     }
 
     private async Task AddProperty()
@@ -160,4 +182,9 @@ else
     }
 
     private void CancelEdit() => editProp = null;
+
+    public void Dispose()
+    {
+        Api.AuthStateChanged -= OnAuthChanged;
+    }
 }


### PR DESCRIPTION
## Summary
- subscribe to auth changes in Properties page
- load organizations and properties from the API on page load
- dispose event handlers when the component is destroyed

## Testing
- `dotnet build HomeAuthomationAPI.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687786d5726c8321b59492ba302bee72