### PR TITLE
Add API token authentication for client

### DIFF
--- a/ZigbeeHomeAutomation/Helpers/AppSettings.cs
+++ b/ZigbeeHomeAutomation/Helpers/AppSettings.cs
@@ -21,5 +21,7 @@ namespace ZigbeeHomeAutomation.Helpers
         public static string ApiBaseUrl => Configuration["HomeAutomationApi:BaseUrl"] ?? string.Empty;
         public static int ApiSyncIntervalSeconds => int.Parse(Configuration["HomeAutomationApi:SyncIntervalSeconds"] ?? "30");
         public static int DirectMessageIntervalSeconds => int.Parse(Configuration["HomeAutomationApi:DirectMessageIntervalSeconds"] ?? "10");
+        public static string ApiUsername => Configuration["HomeAutomationApi:Username"] ?? "admin";
+        public static string ApiPassword => Configuration["HomeAutomationApi:Password"] ?? "admin";
     }
 }

--- a/ZigbeeHomeAutomation/Program.cs
+++ b/ZigbeeHomeAutomation/Program.cs
@@ -16,6 +16,7 @@ class Program
 
         await ZigbeeHomeAutomation.Helpers.Mqtt.ConnectToMqtt();
         await TuyaClient.InitializeAsync();
+        await HomeAutomationApiClient.AuthenticateAsync();
 
         Console.WriteLine("Connected to MQTT. Starting loop...");
 

--- a/ZigbeeHomeAutomation/appSettings.json
+++ b/ZigbeeHomeAutomation/appSettings.json
@@ -12,6 +12,8 @@
   "HomeAutomationApi": {
     "BaseUrl": "http://localhost:5000/api",
     "SyncIntervalSeconds": 30,
-    "DirectMessageIntervalSeconds": 10
+    "DirectMessageIntervalSeconds": 10,
+    "Username": "admin",
+    "Password": "admin"
   }
 }


### PR DESCRIPTION
## Summary
- load API username/password from config
- implement `AuthenticateAsync` to fetch bearer token
- call authentication from main entrypoint
- add credentials to `appSettings.json`

## Testing
- `dotnet build ZigbeeHomeAutomation.sln -c Release`
- `dotnet build HomeAuthomationAPI.sln -c Release` *(fails: SDK for net9.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68778f97b8f88321a8a1d0f25ac40967