### PR TITLE
Add router sync button

### DIFF
--- a/HomeAutomationBlazor/Components/Pages/RouterDevices.razor
+++ b/HomeAutomationBlazor/Components/Pages/RouterDevices.razor
@@ -24,6 +24,7 @@ else
                 <th>Property</th>
                 <th></th>
                 <th></th>
+                <th></th>
             </tr>
         </thead>
         <tbody>
@@ -56,6 +57,9 @@ else
                     <td>@r.FriendlyName</td>
                     <td>@r.UniqueId</td>
                     <td>@propName</td>
+                    <td>
+                        <button class="btn btn-sm btn-primary me-2" @onclick="() => SyncRouter(r.UniqueId)">Sync</button>
+                    </td>
                     <td>
                         <button class="btn btn-sm btn-secondary me-2" @onclick="() => StartEdit(r)">Edit</button>
                     </td>
@@ -150,4 +154,9 @@ else
     }
 
     private void CancelEdit() => editRouter = null;
+
+    private async Task SyncRouter(string routerUniqueId)
+    {
+        await Api.TriggerRouterSync(routerUniqueId);
+    }
 }

--- a/HomeAutomationBlazor/Services/ApiService.cs
+++ b/HomeAutomationBlazor/Services/ApiService.cs
@@ -118,6 +118,17 @@ public class ApiService
     public async Task DeleteRouterDevice(int id) =>
         await _http.DeleteAsync($"api/routerdevices/{id}");
 
+    public async Task TriggerRouterSync(string routerUniqueId)
+    {
+        var payload = new
+        {
+            routerDeviceId = routerUniqueId,
+            type = "sync"
+        };
+
+        await _http.PostAsJsonAsync("api/directmessages", payload);
+    }
+
     public async Task<List<Device>?> GetDevices() =>
         await _http.GetFromJsonAsync<List<Device>>("api/devices");
 


### PR DESCRIPTION
## Summary
- allow UI to trigger a router sync via API
- show Sync button on Router Devices page

## Testing
- `dotnet build HomeAuthomationAPI.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877914515848321bb2a4f709fbf20f8