### PR TITLE
Improve API service error logging

### DIFF
--- a/HomeAutomationBlazor/Services/ApiService.cs
+++ b/HomeAutomationBlazor/Services/ApiService.cs
@@ -55,7 +55,15 @@ public class ApiService
     {
         try
         {
-            return await _http.GetFromJsonAsync<List<Organisation>>("api/organisations");
+            var response = await _http.GetAsync("api/organisations");
+            if (response.IsSuccessStatusCode)
+            {
+                return await response.Content.ReadFromJsonAsync<List<Organisation>>();
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+            Console.Error.WriteLine($"Error fetching organisations: {response.StatusCode} {content}");
+            return null;
         }
         catch (HttpRequestException ex)
         {


### PR DESCRIPTION
## Summary
- handle non-success codes when fetching organisations in the Blazor app

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877932842148321ac763da646874026