### PR TITLE
Add JWT token docs in Swagger

### DIFF
--- a/HomeAuthomationAPI/Controllers/UsersController.cs
+++ b/HomeAuthomationAPI/Controllers/UsersController.cs
@@ -51,15 +51,22 @@ namespace HomeAuthomationAPI.Controllers
             return CreatedAtAction(nameof(Get), new { id = user.Id }, user);
         }
 
+        /// <summary>
+        /// Authenticate a user and generate a bearer token.
+        /// </summary>
+        /// <param name="dto">User credentials.</param>
+        /// <returns>A JWT bearer token.</returns>
         [HttpPost("login")]
-        public async Task<IActionResult> Login(LoginDto dto)
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<ActionResult<TokenResponse>> Login(LoginDto dto)
         {
             var user = await _context.Users.SingleOrDefaultAsync(u => u.Username == dto.Username);
             if (user == null) return Unauthorized();
             var result = _hasher.VerifyHashedPassword(user, user.PasswordHash, dto.Password);
             if (result != PasswordVerificationResult.Success) return Unauthorized();
             var token = GenerateToken(user);
-            return Ok(new { token });
+            return Ok(new TokenResponse(token));
         }
 
         [HttpPut("{id}")]
@@ -106,5 +113,6 @@ namespace HomeAuthomationAPI.Controllers
         }
 
         public record LoginDto(string Username, string Password);
+        public record TokenResponse(string token);
     }
 }

--- a/HomeAuthomationAPI/HomeAuthomationAPI.csproj
+++ b/HomeAuthomationAPI/HomeAuthomationAPI.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HomeAuthomationAPI/Program.cs
+++ b/HomeAuthomationAPI/Program.cs
@@ -13,6 +13,8 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "Home Automation API", Version = "v1" });
+
     c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
     {
         Name = "Authorization",


### PR DESCRIPTION
## Summary
- document login endpoint with summary and response types
- expose TokenResponse record
- show API info in Swagger config
- enable XML docs for API project

## Testing
- `dotnet build HomeAuthomationAPI.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687793856bd883218254876261493c22