### PR TITLE
Remove authentication requirement

### DIFF
--- a/HomeAuthomationAPI/Controllers/BaseController.cs
+++ b/HomeAuthomationAPI/Controllers/BaseController.cs
@@ -1,12 +1,9 @@
 using HomeAuthomationAPI.Data;
 using HomeAuthomationAPI.Models;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System.Security.Claims;
 
 namespace HomeAuthomationAPI.Controllers
 {
-    [Authorize]
     public abstract class BaseController : ControllerBase
     {
         protected readonly HomeAutomationContext _context;
@@ -16,22 +13,10 @@ namespace HomeAuthomationAPI.Controllers
             _context = context;
         }
 
-        protected int? CurrentUserId
-        {
-            get
-            {
-                var idClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
-                return int.TryParse(idClaim, out var id) ? id : null;
-            }
-        }
+        protected int? CurrentUserId => null;
 
-        protected bool IsGlobalAdmin => User.IsInRole("GlobalAdmin");
+        protected bool IsGlobalAdmin => true;
 
-        protected async Task<User?> GetCurrentUserAsync()
-        {
-            var id = CurrentUserId;
-            if (id == null) return null;
-            return await _context.Users.FindAsync(id.Value);
-        }
+        protected Task<User?> GetCurrentUserAsync() => Task.FromResult<User?>(null);
     }
 }

--- a/HomeAuthomationAPI/Controllers/ConfigurationsController.cs
+++ b/HomeAuthomationAPI/Controllers/ConfigurationsController.cs
@@ -1,6 +1,5 @@
 using HomeAuthomationAPI.Data;
 using HomeAuthomationAPI.Models;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Linq;
@@ -9,7 +8,6 @@ namespace HomeAuthomationAPI.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    [Authorize]
     public class ConfigurationsController : BaseController
     {
         public ConfigurationsController(HomeAutomationContext context) : base(context)

--- a/HomeAuthomationAPI/Controllers/OrganisationsController.cs
+++ b/HomeAuthomationAPI/Controllers/OrganisationsController.cs
@@ -1,6 +1,5 @@
 using HomeAuthomationAPI.Data;
 using HomeAuthomationAPI.Models;
-using Microsoft.AspNetCore.Authorization;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -9,7 +8,6 @@ namespace HomeAuthomationAPI.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    [Authorize]
     public class OrganisationsController : BaseController
     {
         public OrganisationsController(HomeAutomationContext context) : base(context)

--- a/HomeAuthomationAPI/Controllers/PropertiesController.cs
+++ b/HomeAuthomationAPI/Controllers/PropertiesController.cs
@@ -1,6 +1,5 @@
 using HomeAuthomationAPI.Data;
 using HomeAuthomationAPI.Models;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Linq;
@@ -9,7 +8,6 @@ namespace HomeAuthomationAPI.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    [Authorize]
     public class PropertiesController : BaseController
     {
         public PropertiesController(HomeAutomationContext context) : base(context)

--- a/HomeAuthomationAPI/Controllers/RouterDevicesController.cs
+++ b/HomeAuthomationAPI/Controllers/RouterDevicesController.cs
@@ -1,6 +1,5 @@
 using HomeAuthomationAPI.Data;
 using HomeAuthomationAPI.Models;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Linq;
@@ -9,7 +8,6 @@ namespace HomeAuthomationAPI.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    [Authorize]
     public class RouterDevicesController : BaseController
     {
         public RouterDevicesController(HomeAutomationContext context) : base(context)

--- a/HomeAuthomationAPI/Controllers/UsersController.cs
+++ b/HomeAuthomationAPI/Controllers/UsersController.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Text;
 using HomeAuthomationAPI.Data;
 using HomeAuthomationAPI.Models;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -27,14 +26,12 @@ namespace HomeAuthomationAPI.Controllers
         }
 
         [HttpGet]
-        [Authorize]
         public async Task<ActionResult<IEnumerable<User>>> Get()
         {
             return await _context.Users.ToListAsync();
         }
 
         [HttpGet("{id}")]
-        [Authorize]
         public async Task<ActionResult<User>> Get(int id)
         {
             var user = await _context.Users.FindAsync(id);
@@ -70,7 +67,6 @@ namespace HomeAuthomationAPI.Controllers
         }
 
         [HttpPut("{id}")]
-        [Authorize]
         public async Task<IActionResult> Put(int id, User user)
         {
             if (id != user.Id) return BadRequest();
@@ -80,7 +76,6 @@ namespace HomeAuthomationAPI.Controllers
         }
 
         [HttpDelete("{id}")]
-        [Authorize]
         public async Task<IActionResult> Delete(int id)
         {
             var user = await _context.Users.FindAsync(id);

--- a/HomeAuthomationAPI/HomeAuthomationAPI.csproj
+++ b/HomeAuthomationAPI/HomeAuthomationAPI.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.17" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.7">

--- a/HomeAuthomationAPI/Program.cs
+++ b/HomeAuthomationAPI/Program.cs
@@ -1,8 +1,5 @@
 ﻿using HomeAuthomationAPI.Data;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.IdentityModel.Tokens;
-using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using HomeAuthomationAPI.Models;
 using Microsoft.OpenApi.Models;
@@ -14,30 +11,6 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
     c.SwaggerDoc("v1", new OpenApiInfo { Title = "Home Automation API", Version = "v1" });
-
-    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
-    {
-        Name = "Authorization",
-        Type = SecuritySchemeType.Http,
-        Scheme = "Bearer",
-        BearerFormat = "JWT",
-        In = ParameterLocation.Header,
-        Description = "Enter 'Bearer' [space] and then your token in the text input below"
-    });
-
-    c.AddSecurityRequirement(new OpenApiSecurityRequirement
-    {
-        {
-            new OpenApiSecurityScheme
-            {
-                Reference = new OpenApiReference
-                {
-                    Type = ReferenceType.SecurityScheme,
-                    Id = "Bearer"
-                }
-            }, Array.Empty<string>()
-        }
-    });
 });
 
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
@@ -48,21 +21,6 @@ builder.Services.AddDbContext<HomeAutomationContext>(options =>
            .EnableSensitiveDataLogging()
            .LogTo(Console.WriteLine, LogLevel.Information));
 
-builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-    .AddJwtBearer(options =>
-    {
-        options.TokenValidationParameters = new TokenValidationParameters
-        {
-            ValidateIssuer = true,
-            ValidateAudience = false,
-            ValidateIssuerSigningKey = true,
-            ValidIssuer = builder.Configuration["Jwt:Issuer"],
-            IssuerSigningKey = new SymmetricSecurityKey(
-                Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!))
-        };
-    });
-
-builder.Services.AddAuthorization();
 
 var app = builder.Build();
 
@@ -84,8 +42,6 @@ app.UseSwaggerUI(options =>
 
 app.UseHttpsRedirection();
 
-app.UseAuthentication();
-app.UseAuthorization();
 
 app.MapControllers();
 

--- a/ZigbeeHomeAutomation/Helpers/HomeAutomationApiClient.cs
+++ b/ZigbeeHomeAutomation/Helpers/HomeAutomationApiClient.cs
@@ -1,6 +1,5 @@
-using System.Text;
 using System.Net.Http;
-using System.Net.Http.Headers;
+using System.Text;
 using Newtonsoft.Json;
 using ZigbeeHomeAutomation.Models;
 
@@ -9,45 +8,12 @@ namespace ZigbeeHomeAutomation.Helpers
     public static class HomeAutomationApiClient
     {
         private static readonly HttpClient _httpClient = new HttpClient();
-        private static string? _token;
 
-        public static async Task AuthenticateAsync()
+        public static Task AuthenticateAsync()
         {
-            var payload = new
-            {
-                Username = AppSettings.ApiUsername,
-                Password = AppSettings.ApiPassword
-            };
-
-            var json = JsonConvert.SerializeObject(payload);
-            try
-            {
-                var resp = await _httpClient.PostAsync($"{AppSettings.ApiBaseUrl}/users/login",
-                    new StringContent(json, Encoding.UTF8, "application/json"));
-                if (!resp.IsSuccessStatusCode)
-                {
-                    Console.WriteLine($"Authentication failed: {resp.StatusCode}");
-                    return;
-                }
-
-                var body = await resp.Content.ReadAsStringAsync();
-                var tokenResp = JsonConvert.DeserializeObject<TokenResponse>(body);
-                _token = tokenResp?.token;
-                if (_token != null)
-                {
-                    _httpClient.DefaultRequestHeaders.Authorization =
-                        new AuthenticationHeaderValue("Bearer", _token);
-                    Console.WriteLine("Authenticated with Home Automation API.");
-                }
-                else
-                {
-                    Console.WriteLine("Authentication response missing token.");
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Authentication error: {ex.Message}");
-            }
+            // Authentication has been removed; this method is kept for
+            // compatibility but performs no action.
+            return Task.CompletedTask;
         }
 
         public class DirectMessage
@@ -177,9 +143,5 @@ namespace ZigbeeHomeAutomation.Helpers
             }
         }
 
-        private class TokenResponse
-        {
-            public string? token { get; set; }
-        }
     }
 }

--- a/ZigbeeHomeAutomation/Program.cs
+++ b/ZigbeeHomeAutomation/Program.cs
@@ -16,7 +16,6 @@ class Program
 
         await ZigbeeHomeAutomation.Helpers.Mqtt.ConnectToMqtt();
         await TuyaClient.InitializeAsync();
-        await HomeAutomationApiClient.AuthenticateAsync();
 
         Console.WriteLine("Connected to MQTT. Starting loop...");
 


### PR DESCRIPTION
## Summary
- strip all `[Authorize]` attributes and user logic from the API controllers
- remove JWT setup from the API `Program.cs` and project file
- drop the call to authenticate in the Zigbee client and make authentication a no-op

## Testing
- `dotnet build HomeAuthomationAPI.sln` *(fails: NETSDK1045 - current SDK does not support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6877958aa38c83218da14fbe9229199d