### PR TITLE
Fix JSON reference cycle

### DIFF
--- a/HomeAuthomationAPI/Program.cs
+++ b/HomeAuthomationAPI/Program.cs
@@ -2,11 +2,15 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using HomeAuthomationAPI.Models;
+using System.Text.Json.Serialization;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddControllers();
+builder.Services.AddControllers().AddJsonOptions(options =>
+{
+    options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
+});
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {


### PR DESCRIPTION
## Summary
- configure JsonOptions to ignore object reference cycles

## Testing
- `dotnet build HomeAuthomationAPI.sln` *(fails: NETSDK1045 current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6877a051c15c832182c1349d27c4b580