### PR TITLE
Remove RouterDeviceId from Property model

### DIFF
--- a/HomeAuthomationAPI/Controllers/SyncController.cs
+++ b/HomeAuthomationAPI/Controllers/SyncController.cs
@@ -39,11 +39,12 @@ namespace HomeAuthomationAPI.Controllers
             _context.DeviceStatuses.Add(status);
             await _context.SaveChangesAsync();
 
-            var property = await _context.Properties
-                .Include(p => p.Configuration)
-                .FirstOrDefaultAsync(p => p.RouterDeviceId == request.RouterDeviceId);
+            var router = await _context.RouterDevices
+                .Include(r => r.Property)
+                    .ThenInclude(p => p!.Configuration)
+                .FirstOrDefaultAsync(r => r.UniqueId == request.RouterDeviceId);
 
-            string? config = property?.Configuration?.Content;
+            string? config = router?.Property?.Configuration?.Content;
 
             return Ok(new SyncResponse { ConfigurationContent = config });
         }

--- a/HomeAuthomationAPI/Migrations/HomeAutomationContextModelSnapshot.cs
+++ b/HomeAuthomationAPI/Migrations/HomeAutomationContextModelSnapshot.cs
@@ -86,9 +86,6 @@ namespace HomeAuthomationAPI.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
-                    b.Property<string>("RouterDeviceId")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("StatusJson")
                         .IsRequired()
@@ -159,9 +156,6 @@ namespace HomeAuthomationAPI.Migrations
                     b.Property<int>("OrganisationId")
                         .HasColumnType("int");
 
-                    b.Property<string>("RouterDeviceId")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Id");
 

--- a/HomeAuthomationAPI/Models/Property.cs
+++ b/HomeAuthomationAPI/Models/Property.cs
@@ -6,7 +6,6 @@ namespace HomeAuthomationAPI.Models
     {
         public int Id { get; set; }
         public string Name { get; set; } = string.Empty;
-        public string RouterDeviceId { get; set; } = string.Empty;
         public int OrganisationId { get; set; }
         public Organisation? Organisation { get; set; }
         public Configuration? Configuration { get; set; }

--- a/HomeAutomationBlazor/Components/Pages/Properties.razor
+++ b/HomeAutomationBlazor/Components/Pages/Properties.razor
@@ -21,7 +21,6 @@ else
         <thead>
             <tr>
                 <th>Name</th>
-                <th>Router</th>
                 <th>Organisation</th>
                 <th></th>
                 <th></th>
@@ -34,7 +33,6 @@ else
             {
                 <tr>
                     <td><InputText class="form-control" @bind-Value="editProp.Name" /></td>
-                    <td><InputText class="form-control" @bind-Value="editProp.RouterDeviceId" /></td>
                     <td>
                         <InputSelect class="form-select" @bind-Value="editProp.OrganisationId">
                             @if (organisations != null)
@@ -57,7 +55,6 @@ else
             {
                 <tr>
                     <td>@p.Name</td>
-                    <td>@p.RouterDeviceId</td>
                     <td>@(organisations?.FirstOrDefault(o => o.Id == p.OrganisationId)?.Name ?? p.OrganisationId.ToString())</td>
                     <td>
                         <NavLink class="btn btn-sm btn-secondary me-2" href="@($"/properties/{p.Id}")">Manage</NavLink>
@@ -77,9 +74,6 @@ else
         <div class="row g-2 mb-3">
             <div class="col">
                 <InputText class="form-control" placeholder="Name" @bind-Value="newProp.Name" />
-            </div>
-            <div class="col">
-                <InputText class="form-control" placeholder="Router" @bind-Value="newProp.RouterDeviceId" />
             </div>
             <div class="col">
                 <InputSelect class="form-select" @bind-Value="newProp.OrganisationId">
@@ -162,7 +156,6 @@ else
         {
             Id = prop.Id,
             Name = prop.Name,
-            RouterDeviceId = prop.RouterDeviceId,
             OrganisationId = prop.OrganisationId
         };
     }
@@ -175,7 +168,6 @@ else
         if (existing != null)
         {
             existing.Name = editProp.Name;
-            existing.RouterDeviceId = editProp.RouterDeviceId;
             existing.OrganisationId = editProp.OrganisationId;
         }
         editProp = null;

--- a/HomeAutomationBlazor/Models/Property.cs
+++ b/HomeAutomationBlazor/Models/Property.cs
@@ -4,6 +4,5 @@ public class Property
 {
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;
-    public string RouterDeviceId { get; set; } = string.Empty;
     public int OrganisationId { get; set; }
 }


### PR DESCRIPTION
## Summary
- refactor Property models to remove `RouterDeviceId`
- adapt SyncController to locate properties via router devices
- update Property management page to drop router column
- update EF Core snapshot

## Testing
- `dotnet build HomeAuthomationAPI.sln -nologo` *(fails: NETSDK1045 - .NET 9.0 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6877a49846d083218d563f52687f81e6