### PR TITLE
Fix interactive server render mode for layout

### DIFF
--- a/HomeAutomationBlazor/Components/Layout/MainLayout.razor
+++ b/HomeAutomationBlazor/Components/Layout/MainLayout.razor
@@ -1,4 +1,3 @@
-@rendermode InteractiveServer
 @inherits LayoutComponentBase
 
 <div class="page">


### PR DESCRIPTION
## Summary
- remove interactive server render mode from `MainLayout`

## Testing
- `dotnet build ZigbeeHomeAutomation.sln`
- `dotnet build HomeAutomationBlazor/HomeAutomationBlazor.csproj`
- `dotnet run --project HomeAutomationBlazor/HomeAutomationBlazor.csproj --urls=http://localhost:5000` *(manual run to ensure startup)*

------
https://chatgpt.com/codex/tasks/task_e_6877b35c6c8c8321b4ae2208df2b6533