### PR TITLE
Update DeviceStatus model to link devices

### DIFF
--- a/HomeAuthomationAPI/Controllers/DeviceStatusesController.cs
+++ b/HomeAuthomationAPI/Controllers/DeviceStatusesController.cs
@@ -16,11 +16,11 @@ public class DeviceStatusesController : ControllerBase
         _context = context;
     }
 
-    [HttpGet("latest/{routerDeviceId}")]
-    public async Task<ActionResult<DeviceStatus>> GetLatest(string routerDeviceId)
+    [HttpGet("latest/{deviceId}")]
+    public async Task<ActionResult<DeviceStatus>> GetLatest(int deviceId)
     {
         var status = await _context.DeviceStatuses
-            .Where(s => s.RouterDeviceId == routerDeviceId)
+            .Where(s => s.DeviceId == deviceId)
             .OrderByDescending(s => s.Timestamp)
             .FirstOrDefaultAsync();
         if (status == null) return NotFound();

--- a/HomeAuthomationAPI/Data/HomeAutomationContext.cs
+++ b/HomeAuthomationAPI/Data/HomeAutomationContext.cs
@@ -53,6 +53,11 @@ namespace HomeAuthomationAPI.Data
                 .HasMany(r => r.Configurations)
                 .WithOne(c => c.RouterDevice)
                 .HasForeignKey(c => c.RouterDeviceId);
+
+            modelBuilder.Entity<DeviceStatus>()
+                .HasOne(ds => ds.Device)
+                .WithMany()
+                .HasForeignKey(ds => ds.DeviceId);
         }
     }
 }

--- a/HomeAuthomationAPI/Migrations/20250717120000_DeviceStatusReferencesDevice.cs
+++ b/HomeAuthomationAPI/Migrations/20250717120000_DeviceStatusReferencesDevice.cs
@@ -1,0 +1,61 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HomeAuthomationAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class DeviceStatusReferencesDevice : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RouterDeviceId",
+                table: "DeviceStatuses");
+
+            migrationBuilder.AddColumn<int>(
+                name: "DeviceId",
+                table: "DeviceStatuses",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceStatuses_DeviceId",
+                table: "DeviceStatuses",
+                column: "DeviceId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DeviceStatuses_Devices_DeviceId",
+                table: "DeviceStatuses",
+                column: "DeviceId",
+                principalTable: "Devices",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_DeviceStatuses_Devices_DeviceId",
+                table: "DeviceStatuses");
+
+            migrationBuilder.DropIndex(
+                name: "IX_DeviceStatuses_DeviceId",
+                table: "DeviceStatuses");
+
+            migrationBuilder.DropColumn(
+                name: "DeviceId",
+                table: "DeviceStatuses");
+
+            migrationBuilder.AddColumn<string>(
+                name: "RouterDeviceId",
+                table: "DeviceStatuses",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/HomeAuthomationAPI/Migrations/HomeAutomationContextModelSnapshot.cs
+++ b/HomeAuthomationAPI/Migrations/HomeAutomationContextModelSnapshot.cs
@@ -86,6 +86,8 @@ namespace HomeAuthomationAPI.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
+                    b.Property<int>("DeviceId")
+                        .HasColumnType("int");
 
                     b.Property<string>("StatusJson")
                         .IsRequired()
@@ -95,6 +97,8 @@ namespace HomeAuthomationAPI.Migrations
                         .HasColumnType("datetime2");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("DeviceId");
 
                     b.ToTable("DeviceStatuses");
                 });
@@ -258,6 +262,17 @@ namespace HomeAuthomationAPI.Migrations
                 {
                     b.HasOne("HomeAuthomationAPI.Models.Device", "Device")
                         .WithMany("Parameters")
+                        .HasForeignKey("DeviceId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Device");
+                });
+
+            modelBuilder.Entity("HomeAuthomationAPI.Models.DeviceStatus", b =>
+                {
+                    b.HasOne("HomeAuthomationAPI.Models.Device", "Device")
+                        .WithMany()
                         .HasForeignKey("DeviceId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();

--- a/HomeAuthomationAPI/Models/DeviceStatus.cs
+++ b/HomeAuthomationAPI/Models/DeviceStatus.cs
@@ -3,7 +3,8 @@ namespace HomeAuthomationAPI.Models
     public class DeviceStatus
     {
         public int Id { get; set; }
-        public string RouterDeviceId { get; set; } = string.Empty;
+        public int DeviceId { get; set; }
+        public Device? Device { get; set; }
         public DateTime Timestamp { get; set; }
         public string StatusJson { get; set; } = string.Empty;
     }

--- a/HomeAutomationBlazor/Components/Pages/RouterDevices.razor
+++ b/HomeAutomationBlazor/Components/Pages/RouterDevices.razor
@@ -236,24 +236,14 @@ else
     private async Task ShowStatus(Device device)
     {
         selectedDevice = device;
-        var router = routers!.FirstOrDefault(r => r.Id == device.RouterDeviceId);
-        if (router == null)
-        {
-            selectedStatus = null;
-            currentStatus = null;
-            showStatusModal = true;
-            return;
-        }
 
-        selectedStatus = await Api.GetLatestDeviceStatus(router.UniqueId);
+        selectedStatus = await Api.GetLatestDeviceStatus(device.Id);
         currentStatus = null;
         if (selectedStatus != null)
         {
             try
             {
-                var all = JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, object>>>(selectedStatus.StatusJson);
-                if (all != null && all.TryGetValue(device.Name, out var ds))
-                    currentStatus = ds;
+                currentStatus = JsonSerializer.Deserialize<Dictionary<string, object>>(selectedStatus.StatusJson);
             }
             catch { }
         }

--- a/HomeAutomationBlazor/Models/DeviceStatus.cs
+++ b/HomeAutomationBlazor/Models/DeviceStatus.cs
@@ -3,7 +3,7 @@ namespace HomeAutomationBlazor.Models;
 public class DeviceStatus
 {
     public int Id { get; set; }
-    public string RouterDeviceId { get; set; } = string.Empty;
+    public int DeviceId { get; set; }
     public DateTime Timestamp { get; set; }
     public string StatusJson { get; set; } = string.Empty;
 }

--- a/HomeAutomationBlazor/Services/ApiService.cs
+++ b/HomeAutomationBlazor/Services/ApiService.cs
@@ -155,8 +155,8 @@ public class ApiService
     public async Task DeleteDevice(int id) =>
         await _http.DeleteAsync($"api/devices/{id}");
 
-    public async Task<DeviceStatus?> GetLatestDeviceStatus(string routerDeviceId) =>
-        await _http.GetFromJsonAsync<DeviceStatus>($"api/devicestatuses/latest/{routerDeviceId}");
+    public async Task<DeviceStatus?> GetLatestDeviceStatus(int deviceId) =>
+        await _http.GetFromJsonAsync<DeviceStatus>($"api/devicestatuses/latest/{deviceId}");
 
     public async Task<List<Configuration>?> GetConfigurations() =>
         await _http.GetFromJsonAsync<List<Configuration>>("api/configurations");


### PR DESCRIPTION
## Summary
- connect `DeviceStatus` to `Device` instead of router
- update API endpoints and sync logic for new status structure
- adapt Blazor frontend for new API usage
- add EF migration and update model snapshot

## Testing
- `dotnet build HomeAuthomationAPI/HomeAuthomationAPI.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878a0d5ad748321a34726e179e513a9