### PR TITLE
Add DeviceType entity and update relations

### DIFF
--- a/HomeAuthomationAPI/Controllers/DevicesController.cs
+++ b/HomeAuthomationAPI/Controllers/DevicesController.cs
@@ -19,7 +19,8 @@ namespace HomeAuthomationAPI.Controllers
         public async Task<ActionResult<IEnumerable<Device>>> Get()
         {
             return await _context.Devices
-                .Include(d => d.Parameters)
+                .Include(d => d.DeviceType)
+                    .ThenInclude(dt => dt.Parameters)
                 .Include(d => d.Configurations)
                 .ToListAsync();
         }
@@ -28,7 +29,8 @@ namespace HomeAuthomationAPI.Controllers
         public async Task<ActionResult<Device>> Get(int id)
         {
             var device = await _context.Devices
-                .Include(d => d.Parameters)
+                .Include(d => d.DeviceType)
+                    .ThenInclude(dt => dt.Parameters)
                 .Include(d => d.Configurations)
                 .FirstOrDefaultAsync(d => d.Id == id);
             if (device == null) return NotFound();
@@ -47,6 +49,7 @@ namespace HomeAuthomationAPI.Controllers
         {
             public string RouterDeviceUniqueId { get; set; } = string.Empty;
             public string Name { get; set; } = string.Empty;
+            public int DeviceTypeId { get; set; }
         }
 
         [HttpPost("register")]
@@ -54,7 +57,7 @@ namespace HomeAuthomationAPI.Controllers
         {
             var router = await _context.RouterDevices.FirstOrDefaultAsync(r => r.UniqueId == reg.RouterDeviceUniqueId);
             if (router == null) return BadRequest();
-            var device = new Device { Name = reg.Name, RouterDeviceId = router.Id };
+            var device = new Device { Name = reg.Name, RouterDeviceId = router.Id, DeviceTypeId = reg.DeviceTypeId };
             _context.Devices.Add(device);
             await _context.SaveChangesAsync();
             return Ok(device);

--- a/HomeAuthomationAPI/Data/HomeAutomationContext.cs
+++ b/HomeAuthomationAPI/Data/HomeAutomationContext.cs
@@ -17,6 +17,7 @@ namespace HomeAuthomationAPI.Data
         public DbSet<RouterDevice> RouterDevices => Set<RouterDevice>();
         public DbSet<Device> Devices => Set<Device>();
         public DbSet<Parameter> Parameters => Set<Parameter>();
+        public DbSet<DeviceType> DeviceTypes => Set<DeviceType>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -39,10 +40,15 @@ namespace HomeAuthomationAPI.Data
                 .WithOne(d => d.RouterDevice)
                 .HasForeignKey(d => d.RouterDeviceId);
 
-            modelBuilder.Entity<Device>()
-                .HasMany(d => d.Parameters)
-                .WithOne(p => p.Device!)
-                .HasForeignKey(p => p.DeviceId);
+            modelBuilder.Entity<DeviceType>()
+                .HasMany(dt => dt.Devices)
+                .WithOne(d => d.DeviceType)
+                .HasForeignKey(d => d.DeviceTypeId);
+
+            modelBuilder.Entity<DeviceType>()
+                .HasMany(dt => dt.Parameters)
+                .WithOne(p => p.DeviceType)
+                .HasForeignKey(p => p.DeviceTypeId);
 
             modelBuilder.Entity<Device>()
                 .HasMany(d => d.Configurations)

--- a/HomeAuthomationAPI/Migrations/20250717090000_addDeviceTypes.cs
+++ b/HomeAuthomationAPI/Migrations/20250717090000_addDeviceTypes.cs
@@ -1,0 +1,98 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HomeAuthomationAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class addDeviceTypes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DeviceTypes",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DeviceTypes", x => x.Id);
+                });
+
+            migrationBuilder.AddColumn<int>(
+                name: "DeviceTypeId",
+                table: "Devices",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "DeviceTypeId",
+                table: "Parameters",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Devices_DeviceTypeId",
+                table: "Devices",
+                column: "DeviceTypeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Parameters_DeviceTypeId",
+                table: "Parameters",
+                column: "DeviceTypeId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Devices_DeviceTypes_DeviceTypeId",
+                table: "Devices",
+                column: "DeviceTypeId",
+                principalTable: "DeviceTypes",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Parameters_DeviceTypes_DeviceTypeId",
+                table: "Parameters",
+                column: "DeviceTypeId",
+                principalTable: "DeviceTypes",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Devices_DeviceTypes_DeviceTypeId",
+                table: "Devices");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Parameters_DeviceTypes_DeviceTypeId",
+                table: "Parameters");
+
+            migrationBuilder.DropTable(
+                name: "DeviceTypes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Devices_DeviceTypeId",
+                table: "Devices");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Parameters_DeviceTypeId",
+                table: "Parameters");
+
+            migrationBuilder.DropColumn(
+                name: "DeviceTypeId",
+                table: "Devices");
+
+            migrationBuilder.DropColumn(
+                name: "DeviceTypeId",
+                table: "Parameters");
+        }
+    }
+}

--- a/HomeAuthomationAPI/Models/Device.cs
+++ b/HomeAuthomationAPI/Models/Device.cs
@@ -8,7 +8,8 @@ namespace HomeAuthomationAPI.Models
         public string Name { get; set; } = string.Empty;
         public int RouterDeviceId { get; set; }
         public RouterDevice? RouterDevice { get; set; }
-        public ICollection<Parameter> Parameters { get; set; } = new List<Parameter>();
+        public int DeviceTypeId { get; set; }
+        public DeviceType? DeviceType { get; set; }
         public ICollection<Configuration> Configurations { get; set; } = new List<Configuration>();
         public ICollection<DeviceStatus> DeviceStatuses { get; set; } = new List<DeviceStatus>();
     }

--- a/HomeAuthomationAPI/Models/DeviceType.cs
+++ b/HomeAuthomationAPI/Models/DeviceType.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace HomeAuthomationAPI.Models
+{
+    public class DeviceType
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public ICollection<Device> Devices { get; set; } = new List<Device>();
+        public ICollection<Parameter> Parameters { get; set; } = new List<Parameter>();
+    }
+}

--- a/HomeAuthomationAPI/Models/Parameter.cs
+++ b/HomeAuthomationAPI/Models/Parameter.cs
@@ -7,7 +7,7 @@ namespace HomeAuthomationAPI.Models
         public int Id { get; set; }
         public string Name { get; set; } = string.Empty;
         public bool IsSensor { get; set; }
-        public int DeviceId { get; set; }
-        public Device? Device { get; set; }
+        public int DeviceTypeId { get; set; }
+        public DeviceType? DeviceType { get; set; }
     }
 }

--- a/HomeAutomationBlazor/Components/Pages/Configurations.razor
+++ b/HomeAutomationBlazor/Components/Pages/Configurations.razor
@@ -363,21 +363,21 @@ else
     {
         var deviceName = e.Value?.ToString();
         var dev = devices?.FirstOrDefault(d => d.Name == deviceName);
-        parameterOptions = dev?.Parameters;
+        parameterOptions = dev?.DeviceType?.Parameters;
     }
 
     private void UpdateTrueOptions(ChangeEventArgs e)
     {
         var deviceName = e.Value?.ToString();
         var dev = devices?.FirstOrDefault(d => d.Name == deviceName);
-        trueOptions = dev?.Parameters;
+        trueOptions = dev?.DeviceType?.Parameters;
     }
 
     private void UpdateFalseOptions(ChangeEventArgs e)
     {
         var deviceName = e.Value?.ToString();
         var dev = devices?.FirstOrDefault(d => d.Name == deviceName);
-        falseOptions = dev?.Parameters;
+        falseOptions = dev?.DeviceType?.Parameters;
     }
 
     private void AddCondition()

--- a/HomeAutomationBlazor/Models/AutomationConfiguration.cs
+++ b/HomeAutomationBlazor/Models/AutomationConfiguration.cs
@@ -23,7 +23,7 @@ public class ActionDefinition
     public string deviceName { get; set; } = string.Empty;
     public string paramiterName { get; set; } = string.Empty;
     public string state { get; set; } = string.Empty;
-    public DeviceType deviceType { get; set; } = DeviceType.Zigbee;
+    public AutomationDeviceType deviceType { get; set; } = AutomationDeviceType.Zigbee;
 }
 
 public class Condition
@@ -40,10 +40,10 @@ public class Sensor
     public string deviceName { get; set; } = string.Empty;
     public string paramiterName { get; set; } = string.Empty;
     public string state { get; set; } = string.Empty;
-    public DeviceType deviceType { get; set; } = DeviceType.Zigbee;
+    public AutomationDeviceType deviceType { get; set; } = AutomationDeviceType.Zigbee;
 }
 
-public enum DeviceType
+public enum AutomationDeviceType
 {
     Zigbee,
     Tuya

--- a/HomeAutomationBlazor/Models/Device.cs
+++ b/HomeAutomationBlazor/Models/Device.cs
@@ -5,5 +5,6 @@ public class Device
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public int RouterDeviceId { get; set; }
-    public List<Parameter>? Parameters { get; set; }
+    public int DeviceTypeId { get; set; }
+    public DeviceType? DeviceType { get; set; }
 }

--- a/HomeAutomationBlazor/Models/DeviceType.cs
+++ b/HomeAutomationBlazor/Models/DeviceType.cs
@@ -1,9 +1,8 @@
 namespace HomeAutomationBlazor.Models;
 
-public class Parameter
+public class DeviceType
 {
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;
-    public bool IsSensor { get; set; }
-    public int DeviceTypeId { get; set; }
+    public List<Parameter>? Parameters { get; set; }
 }


### PR DESCRIPTION
## Summary
- introduce `DeviceType` model for HomeAuthomationAPI and Blazor
- link devices to device types and parameters to device types
- update EF context and migration for new relations
- adjust APIs and UI to use `DeviceType`
- rename enum in automation config to avoid class conflict

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6878f09708748321aad829d0c5ff05d5