### PR TITLE
Allow admin management of Parameter visibility

### DIFF
--- a/HomeAuthomationAPI/Controllers/ParametersController.cs
+++ b/HomeAuthomationAPI/Controllers/ParametersController.cs
@@ -1,0 +1,60 @@
+using HomeAuthomationAPI.Data;
+using HomeAuthomationAPI.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HomeAuthomationAPI.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ParametersController : BaseController
+{
+    public ParametersController(HomeAutomationContext context) : base(context)
+    {
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<Parameter>>> Get()
+    {
+        return await _context.Parameters
+            .Include(p => p.DeviceType)
+            .ToListAsync();
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<Parameter>> Get(int id)
+    {
+        var parameter = await _context.Parameters
+            .Include(p => p.DeviceType)
+            .FirstOrDefaultAsync(p => p.Id == id);
+        if (parameter == null) return NotFound();
+        return parameter;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<Parameter>> Post(Parameter parameter)
+    {
+        _context.Parameters.Add(parameter);
+        await _context.SaveChangesAsync();
+        return CreatedAtAction(nameof(Get), new { id = parameter.Id }, parameter);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Put(int id, Parameter parameter)
+    {
+        if (id != parameter.Id) return BadRequest();
+        _context.Entry(parameter).State = EntityState.Modified;
+        await _context.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var parameter = await _context.Parameters.FindAsync(id);
+        if (parameter == null) return NotFound();
+        _context.Parameters.Remove(parameter);
+        await _context.SaveChangesAsync();
+        return NoContent();
+    }
+}

--- a/HomeAutomationBlazor/Components/Layout/NavMenu.razor
+++ b/HomeAutomationBlazor/Components/Layout/NavMenu.razor
@@ -59,6 +59,15 @@
                 </NavLink>
             </div>
 
+            @if (Api.IsGlobalAdmin)
+            {
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="parameters">
+                        <span class="bi bi-toggles2" aria-hidden="true"></span> Parameters
+                    </NavLink>
+                </div>
+            }
+
             <div class="nav-item px-3">
                 <NavLink class="nav-link" href="users">
                     <span class="bi bi-people" aria-hidden="true"></span> Users

--- a/HomeAutomationBlazor/Components/Pages/Parameters.razor
+++ b/HomeAutomationBlazor/Components/Pages/Parameters.razor
@@ -1,0 +1,59 @@
+@page "/parameters"
+@rendermode InteractiveServer
+@inject ApiService Api
+@using HomeAutomationBlazor.Models
+
+<PageTitle>Parameters</PageTitle>
+
+@if (!Api.IsAuthenticated)
+{
+    <p>Please <NavLink href="/login">log in</NavLink> to manage parameters.</p>
+}
+else if (parameters == null)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>DeviceTypeId</th>
+                <th>Is Sensor</th>
+                <th>Shown</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var p in parameters)
+        {
+            <tr>
+                <td>@p.Name</td>
+                <td>@p.DeviceTypeId</td>
+                <td>@p.IsSensor</td>
+                <td>
+                    <InputCheckbox @bind-Value="p.IsShown" @onchange="() => Save(p)" disabled="@(!Api.IsGlobalAdmin)" />
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}
+
+@code {
+    private List<Parameter>? parameters;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (Api.IsAuthenticated)
+        {
+            parameters = await Api.GetParameters();
+        }
+    }
+
+    private async Task Save(Parameter p)
+    {
+        if (!Api.IsGlobalAdmin) return;
+        await Api.UpdateParameter(p);
+    }
+}

--- a/HomeAutomationBlazor/Services/ApiService.cs
+++ b/HomeAutomationBlazor/Services/ApiService.cs
@@ -189,6 +189,14 @@ public class ApiService
     public async Task DeleteUser(int id) =>
         await _http.DeleteAsync($"api/users/{id}");
 
+    public async Task<List<Parameter>?> GetParameters() =>
+        await _http.GetFromJsonAsync<List<Parameter>>("api/parameters");
+
+    public async Task UpdateParameter(Parameter param)
+    {
+        await _http.PutAsJsonAsync($"api/parameters/{param.Id}", param);
+    }
+
     private record TokenResponse(string token);
 
     private void ParseToken()


### PR DESCRIPTION
## Summary
- add Parameters API controller for CRUD operations
- extend ApiService with methods to fetch and update parameters
- add Parameters page to edit IsShown value
- show Parameters link in nav for admins

## Testing
- `dotnet build HomeAuthomationAPI.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68809dc1852c8321b9f1e608378401c1