### PR TITLE
Add save button on Parameters page

### DIFF
--- a/HomeAutomationBlazor/Components/Pages/Parameters.razor
+++ b/HomeAutomationBlazor/Components/Pages/Parameters.razor
@@ -32,12 +32,16 @@ else
                 <td>@p.DeviceTypeId</td>
                 <td>@p.IsSensor</td>
                 <td>
-                    <InputCheckbox @bind-Value="p.IsShown" @onchange="() => Save(p)" disabled="@(!Api.IsGlobalAdmin)" />
+                    <InputCheckbox @bind-Value="p.IsShown" disabled="@(!Api.IsGlobalAdmin)" />
                 </td>
             </tr>
         }
         </tbody>
     </table>
+    @if (Api.IsGlobalAdmin)
+    {
+        <button class="btn btn-primary" @onclick="SaveAll">Save</button>
+    }
 }
 
 @code {
@@ -51,9 +55,12 @@ else
         }
     }
 
-    private async Task Save(Parameter p)
+    private async Task SaveAll()
     {
-        if (!Api.IsGlobalAdmin) return;
-        await Api.UpdateParameter(p);
+        if (!Api.IsGlobalAdmin || parameters == null) return;
+        foreach (var param in parameters)
+        {
+            await Api.UpdateParameter(param);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add Save button for global admins on Parameters page
- update code to save all parameters when button clicked

## Testing
- `dotnet build HomeAuthomationAPI.sln -c Release` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6880bfdce36c8321b4a7f9274e66a067