### PR TITLE
Filter parameters by IsShown for non-admins

### DIFF
--- a/HomeAutomationBlazor/Components/Pages/Parameters.razor
+++ b/HomeAutomationBlazor/Components/Pages/Parameters.razor
@@ -48,6 +48,10 @@ else
         if (Api.IsAuthenticated)
         {
             parameters = await Api.GetParameters();
+            if (!Api.IsGlobalAdmin)
+            {
+                parameters = parameters?.Where(p => p.IsShown).ToList();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- show only displayed parameters for non-global admins

## Testing
- `dotnet build HomeAutomationBlazor/HomeAutomationBlazor.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6880c02058d08321904f9a0840b73add