### PR TITLE
Filter parameter dropdowns by IsShown

### DIFF
--- a/HomeAutomationBlazor/Components/Pages/Configurations.razor
+++ b/HomeAutomationBlazor/Components/Pages/Configurations.razor
@@ -363,21 +363,24 @@ else
     {
         var deviceName = e.Value?.ToString();
         var dev = devices?.FirstOrDefault(d => d.Name == deviceName);
-        parameterOptions = dev?.DeviceType?.Parameters;
+        parameterOptions = dev?.DeviceType?.Parameters?
+            .Where(p => p.IsShown);
     }
 
     private void UpdateTrueOptions(ChangeEventArgs e)
     {
         var deviceName = e.Value?.ToString();
         var dev = devices?.FirstOrDefault(d => d.Name == deviceName);
-        trueOptions = dev?.DeviceType?.Parameters;
+        trueOptions = dev?.DeviceType?.Parameters?
+            .Where(p => p.IsShown);
     }
 
     private void UpdateFalseOptions(ChangeEventArgs e)
     {
         var deviceName = e.Value?.ToString();
         var dev = devices?.FirstOrDefault(d => d.Name == deviceName);
-        falseOptions = dev?.DeviceType?.Parameters;
+        falseOptions = dev?.DeviceType?.Parameters?
+            .Where(p => p.IsShown);
     }
 
     private void AddCondition()


### PR DESCRIPTION
## Summary
- show only parameters flagged as `IsShown` for each selected device on the configuration page

## Testing
- `dotnet build HomeAuthomationAPI.sln -v:m` *(fails: NETSDK1045 - The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6880c9007e908321bbaae04209b49aff