### PR TITLE
Fix token persistence

### DIFF
--- a/HomeAutomationBlazor/Components/App.razor
+++ b/HomeAutomationBlazor/Components/App.razor
@@ -13,6 +13,7 @@
 
 <body>
     <Routes />
+    <script src="js/tokenStorage.js"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>
 

--- a/HomeAutomationBlazor/Components/Layout/NavMenu.razor
+++ b/HomeAutomationBlazor/Components/Layout/NavMenu.razor
@@ -1,5 +1,6 @@
 @rendermode InteractiveServer
 @inject ApiService Api
+@inject IJSRuntime JS
 @implements IDisposable
 
 <div class="top-row ps-3 navbar navbar-dark">
@@ -83,9 +84,17 @@
         Api.AuthStateChanged += HandleAuthChanged;
     }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await Api.InitializeAsync(JS);
+        }
+    }
+
     private void HandleAuthChanged() => InvokeAsync(StateHasChanged);
 
-    private void Logout() => Api.Logout();
+    private async Task Logout() => await Api.Logout();
 
     public void Dispose()
     {

--- a/HomeAutomationBlazor/Components/Pages/Home.razor
+++ b/HomeAutomationBlazor/Components/Pages/Home.razor
@@ -49,9 +49,9 @@ else
         }
     }
 
-    private void HandleLogout()
+    private async Task HandleLogout()
     {
-        Api.Logout();
+        await Api.Logout();
         Nav.NavigateTo("/");
     }
 

--- a/HomeAutomationBlazor/Components/Pages/Login.razor
+++ b/HomeAutomationBlazor/Components/Pages/Login.razor
@@ -58,9 +58,9 @@ else
         }
     }
 
-    private void HandleLogout()
+    private async Task HandleLogout()
     {
-        Api.Logout();
+        await Api.Logout();
         Nav.NavigateTo("/");
     }
 

--- a/HomeAutomationBlazor/Program.cs
+++ b/HomeAutomationBlazor/Program.cs
@@ -21,7 +21,8 @@ public class Program
         builder.Services.AddScoped<ApiService>(sp =>
         {
             var factory = sp.GetRequiredService<IHttpClientFactory>();
-            return new ApiService(factory.CreateClient("Api"));
+            var js = sp.GetRequiredService<IJSRuntime>();
+            return new ApiService(factory.CreateClient("Api"), js);
         });
 
         var app = builder.Build();

--- a/HomeAutomationBlazor/wwwroot/js/tokenStorage.js
+++ b/HomeAutomationBlazor/wwwroot/js/tokenStorage.js
@@ -1,0 +1,13 @@
+window.authToken = {
+    set: function(token) {
+        if (token) {
+            localStorage.setItem('authToken', token);
+        }
+    },
+    get: function() {
+        return localStorage.getItem('authToken');
+    },
+    clear: function() {
+        localStorage.removeItem('authToken');
+    }
+};


### PR DESCRIPTION
## Summary
- persist authentication token via browser localStorage using JS interop
- restore auth state when components first render
- adjust logout methods to clear stored token
- inject JS runtime for ApiService

## Testing
- `dotnet build ../ZigbeeHomeAutomation.sln -clp:ErrorsOnly`

------
https://chatgpt.com/codex/tasks/task_e_6880d9a2370c83218a377aa94942973f