### PR TITLE
Fix JS runtime injection and API init call

### DIFF
--- a/HomeAutomationBlazor/Components/Layout/NavMenu.razor
+++ b/HomeAutomationBlazor/Components/Layout/NavMenu.razor
@@ -88,7 +88,7 @@
     {
         if (firstRender)
         {
-            await Api.InitializeAsync(JS);
+            await Api.InitializeAsync();
         }
     }
 

--- a/HomeAutomationBlazor/Program.cs
+++ b/HomeAutomationBlazor/Program.cs
@@ -1,5 +1,6 @@
 using HomeAutomationBlazor.Components;
 using HomeAutomationBlazor.Services;
+using Microsoft.JSInterop;
 
 namespace HomeAutomationBlazor;
 


### PR DESCRIPTION
## Summary
- add missing `using Microsoft.JSInterop` to `Program.cs`
- update `NavMenu.razor` to use `ApiService.InitializeAsync()` without passing parameters

## Testing
- `dotnet build HomeAutomationBlazor/HomeAutomationBlazor.csproj -nologo`
- `dotnet build ZigbeeHomeAutomation.sln -nologo`
- `dotnet build HomeAuthomationAPI.sln -nologo` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6880de3e50988321978e3c17366042ac