### PR TITLE
Show logged in user in top bar

### DIFF
--- a/HomeAutomationBlazor/Components/Layout/MainLayout.razor
+++ b/HomeAutomationBlazor/Components/Layout/MainLayout.razor
@@ -1,4 +1,6 @@
 @inherits LayoutComponentBase
+@inject ApiService Api
+@implements IDisposable
 
 <div class="page">
     <div class="sidebar">
@@ -7,7 +9,10 @@
 
     <main>
         <div class="top-row px-4">
-            <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
+            @if (Api.IsAuthenticated && !string.IsNullOrEmpty(Api.Username))
+            {
+                <span>Hello, @Api.Username</span>
+            }
         </div>
 
         <article class="content px-4">
@@ -26,9 +31,29 @@
 @code {
     private ErrorBoundary? errorBoundary;
 
+    protected override void OnInitialized()
+    {
+        Api.AuthStateChanged += HandleAuthChanged;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await Api.InitializeAsync();
+        }
+    }
+
     private void Recover()
     {
         errorBoundary?.Recover();
+    }
+
+    private void HandleAuthChanged() => InvokeAsync(StateHasChanged);
+
+    public void Dispose()
+    {
+        Api.AuthStateChanged -= HandleAuthChanged;
     }
 }
 

--- a/HomeAutomationBlazor/Services/ApiService.cs
+++ b/HomeAutomationBlazor/Services/ApiService.cs
@@ -17,6 +17,7 @@ public class ApiService
     public string? Token { get; private set; }
     public bool IsAuthenticated => Token != null;
     public bool IsGlobalAdmin { get; private set; }
+    public string? Username { get; private set; }
     public event Action? AuthStateChanged;
 
     public ApiService(HttpClient http, IJSRuntime js)
@@ -228,12 +229,14 @@ public class ApiService
     private void ParseToken()
     {
         IsGlobalAdmin = false;
+        Username = null;
         if (Token == null)
             return;
         try
         {
             var handler = new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
             var jwt = handler.ReadJwtToken(Token);
+            Username = jwt.Claims.FirstOrDefault(c => c.Type == System.Security.Claims.ClaimTypes.Name)?.Value;
             if (jwt.Claims.FirstOrDefault(c => c.Type == System.Security.Claims.ClaimTypes.Role)?.Value == "GlobalAdmin")
             {
                 IsGlobalAdmin = true;
@@ -249,6 +252,7 @@ public class ApiService
     {
         Token = null;
         IsGlobalAdmin = false;
+        Username = null;
         _http.DefaultRequestHeaders.Authorization = null;
         try
         {


### PR DESCRIPTION
## Summary
- expose `Username` in `ApiService`
- display current user in `MainLayout`
- update layout to respond to auth state changes

## Testing
- `dotnet test HomeAuthomationAPI.Tests/HomeAuthomationAPI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6881e799aca88321a49ca42602e1171c