### PR TITLE
Fix token initialization

### DIFF
--- a/HomeAutomationBlazor/Services/ApiService.cs
+++ b/HomeAutomationBlazor/Services/ApiService.cs
@@ -29,7 +29,6 @@ public class ApiService
     public async Task InitializeAsync()
     {
         if (_initialized) return;
-        _initialized = true;
         try
         {
             var token = await _js.InvokeAsync<string>("authToken.get");
@@ -40,6 +39,7 @@ public class ApiService
                 _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
                 AuthStateChanged?.Invoke();
             }
+            _initialized = true;
         }
         catch
         {


### PR DESCRIPTION
## Summary
- fix initialization for ApiService so JS token retrieval can retry if scripts aren't loaded yet
- keep tests running

## Testing
- `dotnet test HomeAuthomationAPI.sln`

------
https://chatgpt.com/codex/tasks/task_e_68836bf4362083219236c5172820ad21